### PR TITLE
Fix failing integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install git+https://github.com/PennyLaneAI/pennylane.git
           pip install -r requirements.txt
-          pip install wheel pytest pytest-cov pytest-mock --upgrade
+          pip install wheel pytest pytest-cov pytest-mock flaky --upgrade
 
       - name: Install Plugin
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,30 +8,79 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1
         with:
           access_token: ${{ github.token }}
+
       - uses: actions/checkout@v2
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install git+https://github.com/PennyLaneAI/pennylane.git
           pip install -r requirements.txt
           pip install wheel pytest pytest-cov pytest-mock --upgrade
+
       - name: Install Plugin
         run: |
           python setup.py bdist_wheel
           pip install dist/PennyLane*.whl
+
       - name: Run tests
         run: python -m pytest tests --cov=pennylane_qiskit --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.0.7
+        with:
+          file: ./coverage.xml
+
+  integration-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install git+https://github.com/PennyLaneAI/pennylane.git
+          pip install -r requirements.txt
+          pip install wheel pytest pytest-cov pytest-mock --upgrade
+
+      - name: Install Plugin
+        run: |
+          python setup.py bdist_wheel
+          pip install dist/PennyLane*.whl
+
+      - name: Run tests
+        run: |
+          pl-device-test --device=qiskit.basicaer --tb=short --skip-ops --analytic=False --shots=10000 --device-kwargs backend=qasm_simulator
+          pl-device-test --device=qiskit.aer --tb=short --skip-ops --analytic=False --shots=10000 --device-kwargs backend=qasm_simulator
+          pl-device-test --device=qiskit.aer --tb=short --skip-ops --analytic=True --device-kwargs backend=statevector_simulator
+          pl-device-test --device=qiskit.aer --tb=short --skip-ops --analytic=True --device-kwargs backend=unitary_simulator
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -28,7 +28,7 @@ from qiskit.circuit.measure import measure
 from qiskit.compiler import assemble, transpile
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 
-from pennylane import QubitDevice, QuantumFunctionError
+from pennylane import QubitDevice, DeviceError
 
 from ._version import __version__
 
@@ -247,7 +247,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         """Input check for the the QubitStateVector operation."""
         if operation == "QubitStateVector":
             if self.backend_name == "unitary_simulator":
-                raise QuantumFunctionError(
+                raise DeviceError(
                     "The QubitStateVector operation "
                     "is not supported on the unitary simulator backend."
                 )

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -234,6 +234,8 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             if operation.endswith(".inv"):
                 gate = gate.inverse()
+                if "QubitUnitary" in operation:
+                    qregs = list(reversed(qregs))
 
             dag.apply_operation_back(gate, qargs=qregs)
             circuit = dag_to_circuit(dag)

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -224,7 +224,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             qregs = [self._reg[i] for i in wires]
 
-            if operation in ("QubitUnitary", "QubitStateVector"):
+            if operation.split(".inv")[0] in ("QubitUnitary", "QubitStateVector"):
                 # Need to revert the order of the quantum registers used in
                 # Qiskit such that it matches the PennyLane ordering
                 qregs = list(reversed(qregs))
@@ -234,8 +234,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             if operation.endswith(".inv"):
                 gate = gate.inverse()
-                if "QubitUnitary" in operation:
-                    qregs = list(reversed(qregs))
 
             dag.apply_operation_back(gate, qargs=qregs)
             circuit = dag_to_circuit(dag)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pennylane>=0.9.0
 numpy
 networkx>=2.2;python_version>'3.5'
 networkx>=2.2,<2.4;python_version=='3.5'
+pyscf<=1.7.2

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ requirements = [
     "networkx>=2.2;python_version>'3.5'",
     # Networkx 2.4 is the final version with python 3.5 support.
     "networkx>=2.2,<2.4;python_version=='3.5'",
+    "pyscf<=1.7.2"
 ]
 
 info = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ def mock_device(monkeypatch):
 
 @pytest.fixture(scope="function")
 def recorder():
-    return qml.utils.OperationRecorder()
+    return qml._queuing.OperationRecorder()
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -161,7 +161,7 @@ class TestStateApplyUnitarySimulator:
         dev = device(1)
         state = init_state(1)
 
-        with pytest.raises(qml.QuantumFunctionError, match="The QubitStateVector operation is not supported on the unitary simulator backend"):
+        with pytest.raises(qml.DeviceError, match="The QubitStateVector operation is not supported on the unitary simulator backend"):
             dev.apply([qml.QubitStateVector(state, wires=[0])])
 
 @pytest.mark.parametrize("shots", [8192])


### PR DESCRIPTION
* Adds shared device integration tests
* Configures CI to install PL from github master
* Fixes bug where `QubitUnitary().inv()` resulted in both the matrix being inverted _and_ the wires being reversed.
* Updates location of `OperationRecorder` in the tests
* Changes a `QuantumFunctionError` to a `DeviceError`, since (a) this is what the device should be raising, and (b) the shared device tests will only skip a `DeviceError`.