### PR TITLE
Some more polishing of the wires refactor

### DIFF
--- a/pennylane_qiskit/aer.py
+++ b/pennylane_qiskit/aer.py
@@ -33,7 +33,9 @@ class AerDevice(QiskitDevice):
     `Aer provider documentation <https://qiskit.org/documentation/apidoc/aer_provider.html>`_.
 
     Args:
-        wires (int): The number of qubits of the device
+        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['ancilla', 'q1', 'q2']``).
         backend (str): the desired backend
         shots (int): number of circuit evaluations/random samples used
             to estimate expectation values and variances of observables

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -33,7 +33,9 @@ class BasicAerDevice(QiskitDevice):
     `Basic Aer provider documentation <https://qiskit.org/documentation/apidoc/providers_basicaer.html>`_.
 
     Args:
-        wires (int): The number of qubits of the device
+        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['ancilla', 'q1', 'q2']``).
         backend (str): the desired backend
         shots (int): number of circuit evaluations/random samples used
             to estimate expectation values and variances of observables

--- a/pennylane_qiskit/ibmq.py
+++ b/pennylane_qiskit/ibmq.py
@@ -36,7 +36,10 @@ class IBMQDevice(QiskitDevice):
     there is a credit system to limit access to the quantum devices.
 
     Args:
-        wires (int): The number of qubits of the device
+        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['ancilla', 'q1', 'q2']``). Note that for some backends, the number
+            of wires has to match the number of qubits accessible.
         provider (Provider): The IBM Q provider you wish to use. If not provided,
             then the default provider returned by ``IBMQ.get_provider()`` is used.
         backend (str): the desired provider backend

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -84,7 +84,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
             Default value is ``False``.
     """
     name = "Qiskit PennyLane plugin"
-    pennylane_requires = ">=0.9.0"
+    pennylane_requires = ">=0.11.0"
     version = "0.9.0"
     plugin_version = __version__
     author = "Xanadu"
@@ -328,6 +328,5 @@ class QiskitDevice(QubitDevice, abc.ABC):
         if self._state is None:
             return None
 
-        wires = wires or range(self.num_wires)
         prob = self.marginal_prob(np.abs(self._state) ** 2, wires)
         return prob

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -69,7 +69,9 @@ class QiskitDevice(QubitDevice, abc.ABC):
     r"""Abstract Qiskit device for PennyLane.
 
     Args:
-        wires (int): The number of qubits of the device
+        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['ancilla', 'q1', 'q2']``).
         provider (Provider): The Qiskit simulation provider
         backend (str): the desired backend
         shots (int): Number of circuit evaluations/random samples used


### PR DESCRIPTION
This PR adds some items missing in the wires refactor PR #99 :

- Update some device docstrings
- Update required PL version
- Delete superfluous (and in fact wrong) line in `analytic_probabilities`