### PR TITLE
Qiskit v0.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=0.19.1
+qiskit>=0.20
 pennylane>=0.9.0
 numpy
 networkx>=2.2;python_version>'3.5'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 requirements = [
-    "qiskit>=0.19.1",
+    "qiskit>=0.20",
     "pennylane>=0.9.0",
     "numpy",
     "networkx>=2.2;python_version>'3.5'",

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -761,14 +761,8 @@ class TestConverterQasm:
                'x q[2];' \
                'barrier q;' \
                'h q[0];' \
-               'cu1(pi/2) q[1],q[0];' \
                'h q[1];' \
-               'cu1(pi/4) q[2],q[0];' \
-               'cu1(pi/2) q[2],q[1];' \
                'h q[2];' \
-               'cu1(pi/8) q[3],q[0];' \
-               'cu1(pi/4) q[3],q[1];' \
-               'cu1(pi/2) q[3],q[2];' \
                'h q[3];' \
                'measure q -> c;'
 
@@ -812,15 +806,12 @@ class TestConverterQasm:
         assert recorder.queue[5].parameters == []
         assert recorder.queue[5].wires == Wires([3])
 
-        assert len(record) == 11
+        assert len(record) == 5
         # check that the message matches
         assert record[0].message.args[0] == "pennylane_qiskit.converter: The {} instruction is not supported by" \
                                             " PennyLane, and has not been added to the template."\
             .format('Barrier')
         assert record[1].message.args[0] == "pennylane_qiskit.converter: The {} instruction is not supported by" \
-                                            " PennyLane, and has not been added to the template."\
-            .format('CU1Gate')
-        assert record[7].message.args[0] == "pennylane_qiskit.converter: The {} instruction is not supported by" \
                                             " PennyLane, and has not been added to the template."\
             .format('Measure')
 

--- a/tests/test_ibmq.py
+++ b/tests/test_ibmq.py
@@ -114,11 +114,13 @@ def test_load_from_disk(token):
     IBMQ.delete_account()
 
 
-def test_account_error():
+def test_account_error(monkeypatch):
 
     # Token is passed such that the test is skipped if no token was provided
     with pytest.raises(IBMQAccountError, match="No active IBM Q account"):
-        IBMQDevice(wires=1)
+        with monkeypatch.context() as m:
+            m.delenv("IBMQX_TOKEN", raising=False)
+            IBMQDevice(wires=1)
 
 
 @pytest.mark.parametrize("analytic", [False])


### PR DESCRIPTION
* Removes the use of the `CU1` gate in a test which tests for unsupported instructions. The [`CU1` gate](https://github.com/Qiskit/qiskit-terra/blob/33743b54912a257e0d4ae4bc9082341685e91366/qiskit/circuit/library/standard_gates/u.py#L116) is now supported with [Qiskit v0.20](https://qiskit.org/documentation/release_notes.html#qiskit-0-20-0) and is converted using its `to_matrix` method and `QubitUnitary`.
* Monkeypatches the `IBMQX_TOKEN` environment variable in the `test_account_error` case (env var might be defined making the test fail)
* Pins Qiskit to v0.20 in `requirements.txt` and `setup.py`