### PR TITLE
Fix failing Qiskit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,15 @@
 
 ### Bug fixes
 
+* Fixed a bug related to extracting differentiable parameters for the Qiskit
+  converter and PennyLane array indexing.
+  [(#106)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/106)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Josh Izaac, Antal Száva
 
 ---
 

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -69,7 +69,7 @@ def _extract_variable_refs(params: Dict[Parameter, Any]) -> Dict[Parameter, qml.
             if isinstance(v, qml.variable.Variable):
                 variable_refs[k] = v
 
-    return variable_refs   # map qiskit parameters to PennyLane differentiable Variables.
+    return variable_refs  # map qiskit parameters to PennyLane differentiable Variables.
 
 
 def _check_circuit_and_bind_parameters(

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -56,11 +56,20 @@ def _extract_variable_refs(params: Dict[Parameter, Any]) -> Dict[Parameter, qml.
         dict[qiskit.circuit.Parameter, pennylane.variable.Variable]: a dictionary mapping
             qiskit parameters to PennyLane variables
     """
+    variable_refs = {}
     # map qiskit parameters to PennyLane differentiable Variables.
-    if params is None:
-        return {}
+    if params is not None:
+        for k, v in params.items():
 
-    return {k: v for k, v in params.items() if isinstance(v, qml.variable.Variable)}
+            # Values can be arrays of size 1, need to extract the Python scalar
+            # (this can happen e.g. when indexing into a PennyLane numpy array)
+            if isinstance(v, np.ndarray):
+                v = v.item()
+
+            if isinstance(v, qml.variable.Variable):
+                variable_refs[k] = v
+
+    return variable_refs   # map qiskit parameters to PennyLane differentiable Variables.
 
 
 def _check_circuit_and_bind_parameters(

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -989,8 +989,8 @@ class TestConverterIntegration:
             qc_pl(qiskit_param_mapping)
             return qml.expval(qml.PauliX(0) @ qml.PauliY(2))
 
-        dcircuit = qml.grad(circuit, 0)
-        res = dcircuit([theta, phi, varphi])
+        dcircuit = qml.grad(circuit)
+        res = dcircuit(np.array([theta, phi, varphi]))
         expected = [
             np.cos(theta) * np.sin(phi) * np.sin(varphi),
             np.sin(theta) * np.cos(phi) * np.sin(varphi),

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -989,8 +989,8 @@ class TestConverterIntegration:
             qc_pl(qiskit_param_mapping)
             return qml.expval(qml.PauliX(0) @ qml.PauliY(2))
 
-        dcircuit = qml.grad(circuit)
-        res = dcircuit(np.array([theta, phi, varphi]))
+        dcircuit = qml.grad(circuit, 0)
+        res = dcircuit([theta, phi, varphi])
         expected = [
             np.cos(theta) * np.sin(phi) * np.sin(varphi),
             np.sin(theta) * np.cos(phi) * np.sin(varphi),


### PR DESCRIPTION
The test `TestConverterIntegration.test_gradient()` is currently failing in the file `test_converter.py`. This PR fixes the test to ensure it passes.

Note: I am unsure why the test is failing, this is likely worth exploring before merging this PR, to ensure there isn't another issue at play. This could be connected to the latest changes in the `pennylane.numpy` module.

Edit: perhaps due to the new numpy indexing behaviour returning a scalar array?