### PR TITLE
Qiskit v0.23 updates

### DIFF
--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -188,11 +188,8 @@ def load(quantum_circuit: QuantumCircuit):
             # gates exist with a different name)
             # TODO: remove the following when gates have been renamed in PennyLane
             if instruction_name == "UGate":
-                instruction_name = "U3"
-            elif instruction_name == "PhaseGate":
-                instruction_name = "U1"
+                instruction_name = "U3Gate"
 
-            print(instruction_name, inv_map[instruction_name], instruction_name in inv_map and inv_map[instruction_name] in pennylane_ops.ops)
             if instruction_name in inv_map and inv_map[instruction_name] in pennylane_ops.ops:
                 # Extract the bound parameters from the operation. If the bound parameters are a
                 # Qiskit ParameterExpression, then replace it with the corresponding PennyLane

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -187,8 +187,7 @@ def load(quantum_circuit: QuantumCircuit):
             # New Qiskit gates that are not natively supported by PL (identical
             # gates exist with a different name)
             # TODO: remove the following when gates have been renamed in PennyLane
-            if instruction_name == "UGate":
-                instruction_name = "U3Gate"
+            instruction_name = "U3Gate" if instruction_name == "UGate" else instruction_name
 
             if instruction_name in inv_map and inv_map[instruction_name] in pennylane_ops.ops:
                 # Extract the bound parameters from the operation. If the bound parameters are a

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -184,6 +184,15 @@ def load(quantum_circuit: QuantumCircuit):
 
             operation_wires = [wire_map[(qubit.register.name, qubit.index)] for qubit in op[1]]
 
+            # New Qiskit gates that are not natively supported by PL (identical
+            # gates exist with a different name)
+            # TODO: remove the following when gates have been renamed in PennyLane
+            if instruction_name == "UGate":
+                instruction_name = "U3"
+            elif instruction_name == "PhaseGate":
+                instruction_name = "U1"
+
+            print(instruction_name, inv_map[instruction_name], instruction_name in inv_map and inv_map[instruction_name] in pennylane_ops.ops)
             if instruction_name in inv_map and inv_map[instruction_name] in pennylane_ops.ops:
                 # Extract the bound parameters from the operation. If the bound parameters are a
                 # Qiskit ParameterExpression, then replace it with the corresponding PennyLane

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -33,6 +33,24 @@ from pennylane import QubitDevice, DeviceError
 from ._version import __version__
 
 
+# Auxiliary functions for gates subject to deprecation
+def U1Gate(theta):
+    """Auxiliary function for the ``U1Gate``."""
+    return ex.PhaseGate(theta)
+
+def U2Gate(phi, lam):
+    """Auxiliary function for the ``U2Gate``.
+
+    Uses the equation ``u2(phi, lam) = u(pi/2, phi, lam)``.
+    """
+    return ex.U(np.pi/2, phi, lam)
+
+def U3Gate(theta, phi, lam):
+    """Auxiliary function for the ``U3Gate``."""
+    return ex.U(theta, phi, lam)
+
+
+
 QISKIT_OPERATION_MAP = {
     # native PennyLane operations also native to qiskit
     "PauliX": ex.XGate,
@@ -59,10 +77,11 @@ QISKIT_OPERATION_MAP = {
     "QubitUnitary": ex.UnitaryGate,
     "U": ex.UGate,
 
-    # Qiskit gates being deprecated
-    "U1": ex.U1Gate,
-    "U2": ex.U2Gate,
-    "U3": ex.U3Gate
+    # Qiskit gates subject to deprecation (using custom definitions that depend on
+    # the latest recommended gates)
+    "U1": U1Gate,
+    "U2": U2Gate,
+    "U3": U3Gate
 }
 
 # Separate dictionary for the inverses as the operations dictionary needs
@@ -295,7 +314,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
         if self.noise_model:
             # Set the noise model before execution
-            backend.set_options(noise_model=noise_model)
+            backend.set_options(noise_model=self.noise_model)
 
         self._current_job = self.backend.run(qobj, **self.run_args)
         result = self._current_job.result()

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -52,12 +52,17 @@ QISKIT_OPERATION_MAP = {
     "CRX": ex.CRXGate,
     "CRY": ex.CRYGate,
     "CRZ": ex.CRZGate,
-    "PhaseShift": ex.U1Gate,
+    "PhaseShift": ex.PhaseGate,
     "QubitStateVector": ex.Initialize,
-    "U2": ex.U2Gate,
-    "U3": ex.U3Gate,
+
     "Toffoli": ex.CCXGate,
     "QubitUnitary": ex.UnitaryGate,
+    "U": ex.UGate,
+
+    # Qiskit gates being deprecated
+    "U1": ex.U1Gate,
+    "U2": ex.U2Gate,
+    "U3": ex.U3Gate
 }
 
 # Separate dictionary for the inverses as the operations dictionary needs

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -170,24 +170,22 @@ class QiskitDevice(QubitDevice, abc.ABC):
         # Initialize inner state
         self.reset()
 
-        # determine if backend supports backend options and noise models,
-        # and properly put together backend run arguments
-        s = inspect.signature(b.run)
-        self.run_args = {}
         self.compile_backend = None
-
         if "compile_backend" in kwargs:
             self.compile_backend = kwargs.pop("compile_backend")
 
+        aer_provider = str(provider) == "AerProvider"
         self.noise_model = None
         if "noise_model" in kwargs:
-            if str(provider) != "AerProvider" or backend != "qasm_simulator":
+            if not aer_provider or backend != "qasm_simulator":
                 raise ValueError("Backend {} does not support noisy simulations".format(backend))
 
             self.noise_model = kwargs.pop("noise_model")
 
-        if "backend_options" in s.parameters:
-            self.run_args["backend_options"] = kwargs
+        self.run_args = {}
+        if aer_provider:
+            # Consider the remaining kwargs as keyword arguments to run
+            self.run_args.update(kwargs)
 
     @property
     def backend(self):

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -182,10 +182,17 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             self.noise_model = kwargs.pop("noise_model")
 
+        # Get further arguments for run
+        s = inspect.signature(b.run)
         self.run_args = {}
+
         if aer_provider:
             # Consider the remaining kwargs as keyword arguments to run
             self.run_args.update(kwargs)
+
+        elif "backend_options" in s.parameters:
+            # BasicAer
+            self.run_args["backend_options"] = kwargs
 
     @property
     def backend(self):

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -38,17 +38,18 @@ def U1Gate(theta):
     """Auxiliary function for the ``U1Gate``."""
     return ex.PhaseGate(theta)
 
+
 def U2Gate(phi, lam):
     """Auxiliary function for the ``U2Gate``.
 
     Uses the equation ``u2(phi, lam) = u(pi/2, phi, lam)``.
     """
-    return ex.U(np.pi/2, phi, lam)
+    return ex.U(np.pi / 2, phi, lam)
+
 
 def U3Gate(theta, phi, lam):
     """Auxiliary function for the ``U3Gate``."""
     return ex.U(theta, phi, lam)
-
 
 
 QISKIT_OPERATION_MAP = {
@@ -72,16 +73,14 @@ QISKIT_OPERATION_MAP = {
     "CRZ": ex.CRZGate,
     "PhaseShift": ex.PhaseGate,
     "QubitStateVector": ex.Initialize,
-
     "Toffoli": ex.CCXGate,
     "QubitUnitary": ex.UnitaryGate,
     "U": ex.UGate,
-
     # Qiskit gates subject to deprecation (using custom definitions that depend on
     # the latest recommended gates)
     "U1": U1Gate,
     "U2": U2Gate,
-    "U3": U3Gate
+    "U3": U3Gate,
 }
 
 # Separate dictionary for the inverses as the operations dictionary needs
@@ -302,10 +301,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         memory = str(compile_backend) not in self._state_backends
 
         return assemble(
-            experiments=compiled_circuits,
-            backend=compile_backend,
-            shots=self.shots,
-            memory=memory,
+            experiments=compiled_circuits, backend=compile_backend, shots=self.shots, memory=memory
         )
 
     def run(self, qobj):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=0.20
+qiskit>=0.23
 pennylane>=0.11.0
 numpy
 networkx>=2.2;python_version>'3.5'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 requirements = [
-    "qiskit>=0.20",
+    "qiskit>=0.23",
     "pennylane>=0.11.0",
     "numpy",
     "networkx>=2.2;python_version>'3.5'",

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -546,7 +546,7 @@ class TestConverter:
         assert recorder.queue[0].wires == Wires([0, 1])
 
     def test_qiskit_gates_to_be_deprecated(self, recorder):
-        """Tests the Qiskit gates taht will be deprecated in an upcoming Qiskit version.
+        """Tests the Qiskit gates that will be deprecated in an upcoming Qiskit version.
         
         This test case can be removed once the gates are finally deprecated.
         """

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -571,14 +571,14 @@ class TestConverter:
         """Tests that the load method for a QuantumCircuit raises a TypeError,
         if the wrong type of arguments were passed."""
 
-        angle = 'some_string_instead_of_an_angle'
+        angle = np.zeros(4)
 
         qc = QuantumCircuit(3, 1)
         qc.rz(angle, [0])
 
         quantum_circuit = load(qc)
 
-        with pytest.raises(TypeError, match="parameter expected, got <class 'str'>"):
+        with pytest.raises(TypeError, match="Real scalar parameter expected"):
             with recorder:
                 quantum_circuit()
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -548,7 +548,7 @@ class TestConverter:
     def test_qiskit_gates_to_be_deprecated(self, recorder):
         """Tests the Qiskit gates taht will be deprecated in an upcoming Qiskit version.
         
-        This test case will have to be removed once the gates are finally deprecated.
+        This test case can be removed once the gates are finally deprecated.
         """
         qc = QuantumCircuit(1, 1)
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -600,21 +600,6 @@ class TestConverter:
             with recorder:
                 quantum_circuit(params={theta: angle})
 
-    def test_quantum_circuit_error_by_calling_wrong_parameters(self, recorder):
-        """Tests that the load method for a QuantumCircuit raises a TypeError,
-        if the wrong type of arguments were passed."""
-
-        angle = np.zeros(4)
-
-        qc = QuantumCircuit(3, 1)
-        qc.rz(angle, [0])
-
-        quantum_circuit = load(qc)
-
-        with pytest.raises(TypeError, match="Real scalar parameter expected"):
-            with recorder:
-                quantum_circuit()
-
     def test_quantum_circuit_error_passing_parameters_not_required(self, recorder):
         """Tests the load method raises a QiskitError if arguments
         that are not required were passed."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -139,12 +139,11 @@ class TestKeywordArguments:
         with pytest.raises(ValueError, match="does not support noisy simulations"):
             dev = qml.device("qiskit.basicaer", wires=2, noise_model="test value")
 
-    @pytest.mark.parametrize("d", pldevices)
-    def test_overflow_backend_options(self, d):
-        """Test all overflow backend options are extracted"""
-        dev = qml.device(d[0], wires=2, k1="v1", k2="v2")
-        assert dev.run_args["backend_options"]["k1"] == "v1"
-        assert dev.run_args["backend_options"]["k2"] == "v2"
+    def test_overflow_kwargs(self):
+        """Test all overflow kwargs are extracted for the AerDevice"""
+        dev = qml.device('qiskit.aer', wires=2, k1="v1", k2="v2")
+        assert dev.run_args["k1"] == "v1"
+        assert dev.run_args["k2"] == "v2"
 
 
 class TestLoadIntegration:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -131,7 +131,7 @@ class TestKeywordArguments:
         """Test that the noise model argument is properly
         extracted if the backend supports it"""
         dev = qml.device("qiskit.aer", wires=2, noise_model="test value")
-        assert dev.run_args["noise_model"] == "test value"
+        assert dev.noise_model == "test value"
 
     def test_invalid_noise_model(self):
         """Test that the noise model argument causes an exception to be raised


### PR DESCRIPTION
Fix failing tests:
- [X] Converter (due to a new validation in Qiskit, error is raised from there)
- [x] Noise model extraction

*Noise models:*

Due to a [change in the signature of `QasmSimulator.run`](https://github.com/Qiskit/qiskit-aer/blame/f715703c631574565669e5ebc3b8a8b8008a1d34/qiskit/providers/aer/backends/aerbackend.py#L109), `noise_model` is no longer a parameter. A solution using the `set_options` method was added as per the [examples from Qiskit](https://github.com/Qiskit/qiskit-aer/pull/486).

A Qiskit [`NoiseModel` can be defined for the `Aer` provider and the `QasmSimulator`](https://qiskit.org/documentation/stubs/qiskit.providers.aer.noise.NoiseModel.html?highlight=noisemodel). The new solution specifically uses this information.

Updates:
- [X] Change `u3` to `u`, `u1` to `p`, and `u2(φ,λ)` to `u(π/2, φ, λ)`: added the `PhaseGate` and `UGate` gates. The rest of the gates were left to use the soon to be deprecated gates (such that users would be informed about the deprecation.
- [X] Replace `backend_options` with direct `kwargs` for `Aer`

Test cases:
- [ ] Write a test for the noise model
- [ ] Write tests for the auxiliary function operations