### PR TITLE
Test PennyLane tensor unwrapping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 qiskit>=0.23.1
-git+https://github.com/PennyLaneAI/pennylane.git
+pennylane>=0.12.0
 numpy
 networkx>=2.2;python_version>'3.5'
 networkx>=2.2,<2.4;python_version=='3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 qiskit>=0.23.1
-pennylane>=0.12.0
+git+https://github.com/PennyLaneAI/pennylane.git
 numpy
 networkx>=2.2;python_version>'3.5'
 networkx>=2.2,<2.4;python_version=='3.5'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -333,10 +333,7 @@ class TestPLTemplates:
 
             @qml.qnode(dev)
             def circuit(phi=None):
-
-                # Random quantum circuit
                 qml.templates.layers.RandomLayers(phi, wires=list(range(4)))
-
                 return qml.expval(qml.PauliZ(0))
 
             phi = qml.numpy.tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
@@ -348,9 +345,10 @@ class TestPLTemplates:
             assert all([isinstance(x, float) for x in lst])
 
     def test_tensor_unwrapped_gradient_no_error(self, monkeypatch):
-        """Tests that gradient calculations of a circuit that contains
-        RandomLayers taking a differentiable PennyLane tensor execute
-        without error.
+        """Tests that the gradient calculation of a circuit that contains a
+        RandomLayers template taking a PennyLane tensor as differentiable
+        argument executes without error.
+
         The main aim of the test is to check that unwrapping a single element
         tensor does not cause errors.
         """
@@ -358,13 +356,12 @@ class TestPLTemplates:
 
         @qml.qnode(dev)
         def circuit(phi):
-
-            # Random quantum circuit
-            RandomLayers(phi, wires=list(range(4)))
+            qml.templates.layers.RandomLayers(phi, wires=list(range(4)))
             return qml.expval(qml.PauliZ(0))
 
-        phi = tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
+        phi = qml.numpy.tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
 
+        # Check that the jacobian executes without errors
         qml.jacobian(circuit)(phi)
 
 class TestInverses:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -342,6 +342,8 @@ class TestPLTemplates:
                 qml.templates.layers.RandomLayers(phi, wires=list(range(4)))
                 return qml.expval(qml.PauliZ(0))
 
+            # RandomLayers loops over the random_layer function, with each call to random_layer
+            # being passed a `np.tensor` scalar.
             phi = qml.numpy.tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
 
             # Call the QNode, accumulate parameters
@@ -433,8 +435,8 @@ class TestPLTemplates:
         assert rec.queue[0].name == "Rot"
         assert len(rec.queue[0].parameters) == 3
 
-        # Test that the gate parameters are not PennyLane tensors, but a
-        # floats
+        # Test that the gate parameters are not PennyLane tensors,
+        # but are instead floats
         assert not isinstance(rec.queue[0].parameters[0], tensor)
         assert isinstance(rec.queue[0].parameters[0], float)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -369,6 +369,37 @@ class TestPLTemplates:
         # Check that the jacobian executes without errors
         qml.jacobian(circuit)(phi)
 
+    def test_single_gate_parameter(self):
+        """Test that a QNode handles passing multiple tensor objects to the
+        same gate without an error"""
+        dev = qml.device("qiskit.aer", wires=4)
+
+        @qml.qnode(dev)
+        def circuit(phi=None):
+            for y in phi:
+                for idx, x in enumerate(y):
+                    qml.RX(x, wires=idx)
+            return qml.expval(qml.PauliZ(0))
+
+        phi = np.tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
+
+        circuit(phi=phi)
+
+    def test_multiple_gate_parameter(self):
+        """Test that a QNode handles passing multiple tensor objects to the
+        same gate without an error"""
+        dev = qml.device("qiskit.aer", wires=1)
+
+        @qml.qnode(dev)
+        def circuit(phi=None):
+            for idx, x in enumerate(phi):
+                qml.Rot(*x, wires=idx)
+            return qml.expval(qml.PauliZ(0))
+
+        phi = np.tensor([[0.04439891, 0.14490549, 3.29725643]])
+
+        circuit(phi=phi)
+
 class TestInverses:
     """Integration tests checking that the inverse of the operations are applied."""
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,6 +2,7 @@ import sys
 
 import numpy as np
 import pennylane as qml
+from pennylane.numpy import tensor
 import pytest
 import qiskit
 import qiskit.providers.aer as aer
@@ -381,7 +382,7 @@ class TestPLTemplates:
                     qml.RX(x, wires=idx)
             return qml.expval(qml.PauliZ(0))
 
-        phi = np.tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
+        phi = tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
 
         circuit(phi=phi)
 
@@ -396,7 +397,7 @@ class TestPLTemplates:
                 qml.Rot(*x, wires=idx)
             return qml.expval(qml.PauliZ(0))
 
-        phi = np.tensor([[0.04439891, 0.14490549, 3.29725643]])
+        phi = tensor([[0.04439891, 0.14490549, 3.29725643]])
 
         circuit(phi=phi)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -347,6 +347,26 @@ class TestPLTemplates:
             # Check parameters
             assert all([isinstance(x, float) for x in lst])
 
+    def test_tensor_unwrapped_gradient_no_error(self, monkeypatch):
+        """Tests that gradient calculations of a circuit that contains
+        RandomLayers taking a differentiable PennyLane tensor execute
+        without error.
+        The main aim of the test is to check that unwrapping a single element
+        tensor does not cause errors.
+        """
+        dev = qml.device("qiskit.aer", wires=4)
+
+        @qml.qnode(dev)
+        def circuit(phi):
+
+            # Random quantum circuit
+            RandomLayers(phi, wires=list(range(4)))
+            return qml.expval(qml.PauliZ(0))
+
+        phi = tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
+
+        qml.jacobian(circuit)(phi)
+
 class TestInverses:
     """Integration tests checking that the inverse of the operations are applied."""
 


### PR DESCRIPTION
**Context**

This PR adds tests from https://github.com/PennyLaneAI/pennylane/pull/903 using the `qiskit.aer` device. 

Also, see the discussion in https://github.com/PennyLaneAI/pennylane/pull/893 for further details.

These tests cover examples that would be failing with PennyLane version `<0.12.0`:
```python
import pennylane as qml
from pennylane.numpy import tensor

dev = qml.device('qiskit.aer', wires=4)
@qml.qnode(dev)
def circuit(phi=None):
    for y in phi:
        for idx, x in enumerate(y):
            qml.RX(x, wires=idx)
    return qml.expval(qml.PauliZ(0))
phi = tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
circuit(phi=phi)
```
```
~/anaconda3/envs/pl_qiskit/lib/python3.7/site-packages/qiskit/providers/aer/backends/backend_utils.py in cpp_execute(controller, qobj)
     49     qobj_dict['config']['library_dir'] = LIBRARY_DIR
     50 
---> 51     return controller(qobj_dict)
     52 
     53 

RuntimeError: Invalid number of dimensions!
```
**Passing checks - master of PennyLane**
See the passing checks for commit https://github.com/PennyLaneAI/pennylane-qiskit/commit/72b8fe172fcddfead7e1ce4764cdfdac7b8da444 with the master version of PennyLane `git+https://github.com/PennyLaneAI/pennylane.git`: https://github.com/PennyLaneAI/pennylane-qiskit/actions/runs/385779826.

**Failing checks -- PennyLane v0.12.0**
Commit https://github.com/PennyLaneAI/pennylane-qiskit/commit/cbbb4be3f37b5b6b8f962601cb55f862480e4027 and check https://github.com/PennyLaneAI/pennylane-qiskit/runs/1460625139.