### PR TITLE
Qiskit v0.23.1 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Antal Száva
+Olivia Di Matteo, Josh Izaac, Antal Száva
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,21 @@
 
 ### Improvements
 
+* The provided devices are now compatible with Qiskit 0.23.
+  [(#116)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/116)
+
 ### Bug fixes
+
+* The Aer devices store the noise models correctly.
+  [(#112)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/112)
 
 ### Documentation
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Antal Száva
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Bug fixes
 
 * The Aer devices store the noise models correctly.
-  [(#112)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/112)
+  [(#114)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/114)
 
 ### Documentation
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -146,6 +146,8 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             self.analytic = False
 
+        self._backend = None
+
         if "verbose" not in kwargs:
             kwargs["verbose"] = False
 
@@ -223,7 +225,9 @@ class QiskitDevice(QubitDevice, abc.ABC):
     @property
     def backend(self):
         """The Qiskit simulation backend object."""
-        return self.provider.get_backend(self.backend_name)
+        if self._backend is None:
+            self._backend = self.provider.get_backend(self.backend_name)
+        return self._backend
 
     def reset(self):
         # Reset only internal data, not the options that are determined on

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=0.23
+qiskit>=0.23.1
 pennylane>=0.12.0
 numpy
 networkx>=2.2;python_version>'3.5'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 requirements = [
-    "qiskit>=0.23",
+    "qiskit>=0.23.1",
     "pennylane>=0.12.0",
     "numpy",
     "networkx>=2.2;python_version>'3.5'",


### PR DESCRIPTION
**Context**

As per the Qiskit `v0.23.1` release, the backend object returned using the `get_backend` function is now a copy each time:

```python
import qiskit

a = qiskit.Aer.get_backend('qasm_simulator')
b = qiskit.Aer.get_backend('qasm_simulator')

print(a is b)

False
```
This used to not be the case and hence the `QiskitDevice.backend` property got the reference to the same backend object each time.

This change can be perceived by checking the latest PennyLane plugin tests run that use Qiskit v0.23.1:
https://github.com/PennyLaneAI/plugin-test-matrix/runs/1393563190?check_suite_focus=true#step:8:56

**Changes**

* Creates the `QiskitDevice._backend` private object to store a single backend object throughout the execution. This can then be used to persist backend options.
* Pins the requirement to Qiskit `v0.23.1`