### PR TITLE
Incrementing the version number to 0.13.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,14 @@
-# Release 0.13.0-dev
-
-### New features since last release
+# Release 0.13.0
 
 ### Improvements
 
-* The provided devices are now compatible with Qiskit 0.23.
+* The provided devices are now compatible with Qiskit 0.23.1.
   [(#116)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/116)
 
 ### Bug fixes
 
 * The Aer devices store the noise models correctly.
   [(#114)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/114)
-
-### Documentation
 
 ### Contributors
 

--- a/pennylane_qiskit/_version.py
+++ b/pennylane_qiskit/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.13.0-dev"
+__version__ = "0.13.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 qiskit>=0.23.1
-pennylane>=0.12.0
+pennylane>=0.13.0
 numpy
 networkx>=2.2;python_version>'3.5'
 networkx>=2.2,<2.4;python_version=='3.5'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.rst", "r") as fh:
 
 requirements = [
     "qiskit>=0.23.1",
-    "pennylane>=0.12.0",
+    "pennylane>=0.13.0",
     "numpy",
     "networkx>=2.2;python_version>'3.5'",
     # Networkx 2.4 is the final version with python 3.5 support.


### PR DESCRIPTION
* Incrementing the version number of the plugin to `0.13.0`.
* Incremented the PennyLane requirement to `>0.13.0`. This was due to a bug fix in PennyLane included from version `0.13.0` which were previously not covered by the test suite. Related tests were added in https://github.com/PennyLaneAI/pennylane-qiskit/pull/115 (PR not listed in the changelog as it only added tests). 