### PR TITLE
IBMQ token parse precedence update

### DIFF
--- a/pennylane_qiskit/ibmq.py
+++ b/pennylane_qiskit/ibmq.py
@@ -58,8 +58,8 @@ class IBMQDevice(QiskitDevice):
     short_name = "qiskit.ibmq"
 
     def __init__(self, wires, provider=None, backend="ibmq_qasm_simulator", shots=1024, **kwargs):
-        token = os.getenv("IBMQX_TOKEN") or kwargs.get("ibmqx_token", None)
-        url = os.getenv("IBMQX_URL") or kwargs.get("ibmqx_url", None)
+        token = kwargs.get("ibmqx_token", None) or os.getenv("IBMQX_TOKEN")
+        url = kwargs.get("ibmqx_url", None) or os.getenv("IBMQX_URL")
 
         # Specify a single hub, group and project
         hub = kwargs.get("hub", "ibm-q")

--- a/tests/test_ibmq.py
+++ b/tests/test_ibmq.py
@@ -30,6 +30,12 @@ def test_load_from_env(token, monkeypatch):
     dev = IBMQDevice(wires=1)
     assert dev.provider.credentials.is_ibmq()
 
+def test_load_kwargs_takes_precedence(token, monkeypatch):
+    """Test that with a potentially valid token stored as an environment
+    variable, passing the token as a keyword argument takes precedence."""
+    monkeypatch.setenv("IBMQX_TOKEN", "SomePotentiallyValidToken")
+    dev = IBMQDevice(wires=1, ibmqx_token=token)
+    assert dev.provider.credentials.is_ibmq()
 
 def test_account_already_loaded(token):
     """Test loading an IBMQ device using


### PR DESCRIPTION
**Context**
When parsing the IBMQ token and the IBMQ URL, due to the precedence order, values stored in environment variables take effect over values passed as keyword arguments.

**Changes**
Flips the parsing statement to get the precedence correctly.