### PR TITLE
update U gates

### DIFF
--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -33,25 +33,6 @@ from pennylane import QubitDevice, DeviceError
 from ._version import __version__
 
 
-# Auxiliary functions for gates subject to deprecation
-def U1Gate(theta):
-    """Auxiliary function for the ``U1Gate``."""
-    return ex.PhaseGate(theta)
-
-
-def U2Gate(phi, lam):
-    """Auxiliary function for the ``U2Gate``.
-
-    Uses the equation ``u2(phi, lam) = u(pi/2, phi, lam)``.
-    """
-    return ex.U(np.pi / 2, phi, lam)
-
-
-def U3Gate(theta, phi, lam):
-    """Auxiliary function for the ``U3Gate``."""
-    return ex.U(theta, phi, lam)
-
-
 QISKIT_OPERATION_MAP = {
     # native PennyLane operations also native to qiskit
     "PauliX": ex.XGate,
@@ -75,12 +56,9 @@ QISKIT_OPERATION_MAP = {
     "QubitStateVector": ex.Initialize,
     "Toffoli": ex.CCXGate,
     "QubitUnitary": ex.UnitaryGate,
-    "U": ex.UGate,
-    # Qiskit gates subject to deprecation (using custom definitions that depend on
-    # the latest recommended gates)
-    "U1": U1Gate,
-    "U2": U2Gate,
-    "U3": U3Gate,
+    "U1": ex.U1Gate,
+    "U2": ex.U2Gate,
+    "U3": ex.U3Gate,
 }
 
 # Separate dictionary for the inverses as the operations dictionary needs


### PR DESCRIPTION
In the PennyLane device tests, `test_four_qubit_random_circuit` was raising error messages.

The Qiskit `U` gate has been deprecated in favour of individual `U1Gate`, `U2Gate`, `U3Gate`, and `UGate` (which is just `U3Gate`).

This pull requests updates plugin to comply with this Qiskit change.