### PR TITLE
Cast array gate parameters to list

### DIFF
--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -259,6 +259,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             for idx, p in enumerate(par):
                 if isinstance(p, np.ndarray):
+                    # Convert arrays so that Qiskit accepts the parameters
                     par[idx] = p.tolist()
 
             operation = operation.name

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -256,6 +256,10 @@ class QiskitDevice(QubitDevice, abc.ABC):
             # Apply the circuit operations
             device_wires = self.map_wires(operation.wires)
             par = operation.parameters
+
+            if isinstance(par, np.ndarray):
+                par = par.tolist()
+
             operation = operation.name
 
             mapped_operation = self._operation_map[operation]

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -257,8 +257,9 @@ class QiskitDevice(QubitDevice, abc.ABC):
             device_wires = self.map_wires(operation.wires)
             par = operation.parameters
 
-            if isinstance(par, np.ndarray):
-                par = par.tolist()
+            for idx, p in enumerate(par):
+                if isinstance(p, np.ndarray):
+                    par[idx] = p.tolist()
 
             operation = operation.name
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -259,7 +259,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             for idx, p in enumerate(par):
                 if isinstance(p, np.ndarray):
-                    # Convert arrays so that Qiskit accepts the parameters
+                    # Convert arrays so that Qiskit accepts the parameter
                     par[idx] = p.tolist()
 
             operation = operation.name


### PR DESCRIPTION
**Context**

With the release of Qiskit `0.23.3` gate parameters cannot be arrays. This PR adds conversion from arrays to lists.

**Note**

This PR makes the device tests pass for the plugin.