### PR TITLE
increment version number to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.14.0-dev
+# Release 0.14.0
 
 ### New features
 
@@ -8,9 +8,17 @@
 
 ### Bug fixes
 
+* With the release of Qiskit 0.23.3 gate parameters cannot be arrays.  The device now converts arrays to lists.
+  [(#126)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/126)
+
+* When parsing the IBMQ token and the IBMQ URL, the values passed as keywords take precedence over environment variables.
+  [(#121)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/121)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Christina Lee, Antal Szava
 
 ---
 

--- a/pennylane_qiskit/_version.py
+++ b/pennylane_qiskit/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.14.0-dev"
+__version__ = "0.14.0"

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -88,7 +88,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
     """
     name = "Qiskit PennyLane plugin"
     pennylane_requires = ">=0.12.0"
-    version = "0.12.0"
+    version = "0.14.0"
     plugin_version = __version__
     author = "Xanadu"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-qiskit>=0.23.1
-pennylane>=0.13.0
+qiskit>=0.23.4
+pennylane>=0.14.0
 numpy
 networkx>=2.2;python_version>'3.5'
 networkx>=2.2,<2.4;python_version=='3.5'

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 requirements = [
-    "qiskit>=0.23.1",
-    "pennylane>=0.13.0",
+    "qiskit>=0.23.4",
+    "pennylane>=0.14.0",
     "numpy",
     "networkx>=2.2;python_version>'3.5'",
     # Networkx 2.4 is the final version with python 3.5 support.


### PR DESCRIPTION
This pull request increments version number to `0.14.0`.  

The changes involved:
* `pennylane_qiskit/_version.py`'
* `pennylane_qiskit/qiskit_device.py`: `self.version`
* Updating the changelog for recent pull requests that didn't have changelog's
* Bumping `requirements.txt` to most recent version of pennylane and qiskit.