### PR TITLE
Support qiskit version 0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Olivia Di Matteo, Josh Izaac, Antal Szava
+Olivia Di Matteo, Josh Izaac, Antal Száva
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Breaking changes
 
 * For compatibility with PennyLane v0.15, the `analytic` keyword argument
-  has been removed from all devices. Analytic expectation values can
-  still be computed by setting `shots=None`.
+  has been removed from all devices. Statistics can still be computed analytically
+  by setting `shots=None`.
   [(#130)](https://github.com/XanaduAI/pennylane-qiskit/pull/130)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
-# Release 0.15.0-dev
+# Release 0.15.0
 
 ### New features since last release
 
 ### Breaking changes
 
+* For compatibility with PennyLane v0.15, the `analytic` keyword argument
+  has been removed from all devices. Analytic expectation values can
+  still be computed by setting `shots=None`.
+  [(#130)](https://github.com/XanaduAI/pennylane-qiskit/pull/130)
+
 ### Improvements
+
+* PennyLane-Qiskit has been upgraded to work with Qiskit version 0.25.
+  [(#132)](https://github.com/XanaduAI/pennylane-qiskit/pull/132)
 
 ### Documentation
 
@@ -13,6 +21,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Olivia Di Matteo, Josh Izaac, Antal Szava
 
 ---
 

--- a/doc/devices/aer.rst
+++ b/doc/devices/aer.rst
@@ -86,7 +86,7 @@ The options are set via additional keyword arguments:
 For more information on available methods and their options, please visit the `AerSimulator
 documentation <https://qiskit.org/documentation/stubs/qiskit.providers.aer.AerSimulator.html>`_.
 
-.. warnings::
+.. warning::
 
     The ``AerSimulator`` methods ``"stabilizer"``, ``"extended_stabilizer"``, ``"matrix_product_state"``,
     and ``"superop"`` are currently not supported.

--- a/doc/devices/aer.rst
+++ b/doc/devices/aer.rst
@@ -34,7 +34,7 @@ You can then execute the circuit like any other function to get the quantum mech
 Backends
 ~~~~~~~~
 
-The default backend is the ``AerSimulator``. However, multiple other backends might be available.
+The default backend is the ``AerSimulator``. However, multiple other backends are also available.
 To get a current overview what backends are available you can query
 
 .. code-block:: python

--- a/doc/devices/aer.rst
+++ b/doc/devices/aer.rst
@@ -63,7 +63,7 @@ Backend Methods and Options
 
 This ``AerSimulator`` backend has several available methods, which
 can be passed via the ``method`` keyword argument. For example
-``'automatica'``, ``'statevector'``, and ``'unitary'``.
+``'automatic'``, ``'statevector'``, and ``'unitary'``.
 
 .. code-block:: python
 

--- a/doc/devices/aer.rst
+++ b/doc/devices/aer.rst
@@ -86,6 +86,11 @@ The options are set via additional keyword arguments:
 For more information on available methods and their options, please visit the `AerSimulator
 documentation <https://qiskit.org/documentation/stubs/qiskit.providers.aer.AerSimulator.html>`_.
 
+.. warnings::
+
+    The ``AerSimulator`` methods ``"stabilizer"``, ``"extended_stabilizer"``, ``"matrix_product_state"``,
+    and ``"superop"`` are currently not supported.
+
 Noise models
 ~~~~~~~~~~~~
 

--- a/doc/devices/aer.rst
+++ b/doc/devices/aer.rst
@@ -34,11 +34,7 @@ You can then execute the circuit like any other function to get the quantum mech
 Backends
 ~~~~~~~~
 
-Qiskit's Aer layer has several backends, for example ``'qasm_simulator'``,
-``'statevector_simulator'``, ``'unitary_simulator'``. For more information on backends, please visit the
-`Aer provider documentation <https://qiskit.org/documentation/apidoc/aer_provider.html>`_.
-
-
+The default backend is the ``AerSimulator``. However, multiple other backends might be available.
 To get a current overview what backends are available you can query
 
 .. code-block:: python
@@ -60,25 +56,35 @@ You can change a ``'qiskit.aer'`` device's backend with the ``backend`` argument
 
 .. code-block:: python
 
-    dev = qml.device('qiskit.aer', wires=2, backend='unitary_simulator')
+    dev = qml.device('qiskit.aer', wires=2, backend='aer_simulator_statevector')
 
-Backend options
-~~~~~~~~~~~~~~~
+Backend Methods and Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Qiskit's backends can take different *backend options*, for example to specify the numerical
-precision of the simulation.
-You can find a list of backend options in the backends' respective API documentations:
-
-* `'qasm_simulator' <https://qiskit.org/documentation/stubs/qiskit.providers.aer.QasmSimulator.html>`_
-* `'statevector_simulator' <https://qiskit.org/documentation/stubs/qiskit.providers.aer.StatevectorSimulator.html>`_
-* `'unitary_simulator' <https://qiskit.org/documentation/stubs/qiskit.providers.aer.UnitarySimulator.html>`_
-
-The options are set via
+This ``AerSimulator`` backend has several available methods, which
+can be passed via the ``method`` keyword argument. For example
+``'automatica'``, ``'statevector'``, and ``'unitary'``.
 
 .. code-block:: python
 
-    dev = qml.device('qiskit.aer', wires=2, backend='unitary_simulator',
-                     backend_options={"validation_threshold": 1e-6})
+    dev = qml.device("qiskit.aer", wires=2, method="automatic")
+
+Each of these methods can take different *run options*, for example to specify the numerical
+precision of the simulation.
+
+The options are set via additional keyword arguments:
+
+.. code-block:: python
+
+    dev = qml.device(
+        'qiskit.aer',
+        wires=2,
+        backend='unitary_simulator',
+        validation_threshold=1e-6
+    )
+
+For more information on available methods and their options, please visit the `AerSimulator
+documentation <https://qiskit.org/documentation/stubs/qiskit.providers.aer.AerSimulator.html>`_.
 
 Noise models
 ~~~~~~~~~~~~

--- a/pennylane_qiskit/_version.py
+++ b/pennylane_qiskit/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.15.0-dev"
+__version__ = "0.15.0"

--- a/pennylane_qiskit/aer.py
+++ b/pennylane_qiskit/aer.py
@@ -38,6 +38,7 @@ class AerDevice(QiskitDevice):
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['ancilla', 'q1', 'q2']``).
         backend (str): the desired backend
+        method (str): the desired method
         shots (int or None): number of circuit evaluations/random samples used
             to estimate expectation values and variances of observables. For statevector backends,
             setting to ``None`` results in computing statistics like expectation values and variances analytically.
@@ -53,5 +54,8 @@ class AerDevice(QiskitDevice):
 
     short_name = "qiskit.aer"
 
-    def __init__(self, wires, shots=1024, backend="qasm_simulator", **kwargs):
+    def __init__(self, wires, shots=1024, backend="aer_simulator", method="automatic", **kwargs):
+        if method != "automatic":
+            backend += "_" + method
+
         super().__init__(wires, provider=qiskit.Aer, backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/aer.py
+++ b/pennylane_qiskit/aer.py
@@ -38,7 +38,9 @@ class AerDevice(QiskitDevice):
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['ancilla', 'q1', 'q2']``).
         backend (str): the desired backend
-        method (str): the desired method
+        method (str): The desired simulation method. A list of supported simulation
+            methods can be returned using ``qiskit.Aer.available_methods()``, or by referring
+            to the ``AerSimulator`` `documentation <https://qiskit.org/documentation/stubs/qiskit.providers.aer.AerSimulator.html>`__.
         shots (int or None): number of circuit evaluations/random samples used
             to estimate expectation values and variances of observables. For statevector backends,
             setting to ``None`` results in computing statistics like expectation values and variances analytically.

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -171,7 +171,7 @@ def load(quantum_circuit: QuantumCircuit):
         qc = _check_circuit_and_bind_parameters(quantum_circuit, params, var_ref_map)
 
         # Wires from a qiskit circuit are unique w.r.t. a register name and a qubit index
-        qc_wires = [(q.register.name, q.index) for q in quantum_circuit.qubits]
+        qc_wires = [(reg.name, qubit_ind) for reg in quantum_circuit.qregs for qubit_ind, _ in enumerate(reg)]
 
         wire_map = map_wires(wires, qc_wires)
 

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -171,7 +171,11 @@ def load(quantum_circuit: QuantumCircuit):
         qc = _check_circuit_and_bind_parameters(quantum_circuit, params, var_ref_map)
 
         # Wires from a qiskit circuit are unique w.r.t. a register name and a qubit index
-        qc_wires = [(reg.name, qubit_ind) for reg in quantum_circuit.qregs for qubit_ind, _ in enumerate(reg)]
+        qc_wires = [
+            (reg.name, qubit_ind)
+            for reg in quantum_circuit.qregs
+            for qubit_ind, _ in enumerate(reg)
+        ]
 
         wire_map = map_wires(wires, qc_wires)
 

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -170,12 +170,8 @@ def load(quantum_circuit: QuantumCircuit):
         var_ref_map = _extract_variable_refs(params)
         qc = _check_circuit_and_bind_parameters(quantum_circuit, params, var_ref_map)
 
-        # Wires from a qiskit circuit are unique w.r.t. a register name and a qubit index
-        qc_wires = [
-            (reg.name, qubit_ind)
-            for reg in quantum_circuit.qregs
-            for qubit_ind, _ in enumerate(reg)
-        ]
+        # Wires from a qiskit circuit have unique IDs, so their hashes are unique too
+        qc_wires = [hash(q) for q in qc.qubits]
 
         wire_map = map_wires(wires, qc_wires)
 
@@ -184,7 +180,7 @@ def load(quantum_circuit: QuantumCircuit):
 
             instruction_name = op[0].__class__.__name__
 
-            operation_wires = [wire_map[(qubit.register.name, qubit.index)] for qubit in op[1]]
+            operation_wires = [wire_map[hash(qubit)] for qubit in op[1]]
 
             # New Qiskit gates that are not natively supported by PL (identical
             # gates exist with a different name)

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -93,7 +93,12 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
     _capabilities = {"model": "qubit", "tensor_observables": True, "inverse_operations": True}
     _operation_map = {**QISKIT_OPERATION_MAP, **QISKIT_OPERATION_INVERSES_MAP}
-    _state_backends = {"statevector_simulator", "unitary_simulator", "aer_simulator_statevector", "aer_simulator_unitary"}
+    _state_backends = {
+        "statevector_simulator",
+        "unitary_simulator",
+        "aer_simulator_statevector",
+        "aer_simulator_unitary",
+    }
     """set[str]: Set of backend names that define the backends
     that support returning the underlying quantum statevector"""
 
@@ -235,8 +240,8 @@ class QiskitDevice(QubitDevice, abc.ABC):
                 self._circuit.save_state()
 
         # These operations need to run for all devices
-        qobj = self.compile()
-        self.run(qobj)
+        compiled_circuit = self.compile()
+        self.run(compiled_circuit)
 
     def apply_operations(self, operations):
         """Apply the circuit operations.

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -27,6 +27,7 @@ from qiskit import extensions as ex
 from qiskit.circuit.measure import measure
 from qiskit.compiler import assemble, transpile
 from qiskit.converters import circuit_to_dag, dag_to_circuit
+from qiskit.providers.aer.library import save_state
 
 from pennylane import QubitDevice, DeviceError
 
@@ -85,14 +86,14 @@ class QiskitDevice(QubitDevice, abc.ABC):
             to simulate a device compliant circuit, you can specify a backend here.
     """
     name = "Qiskit PennyLane plugin"
-    pennylane_requires = ">=0.12.0"
-    version = "0.14.0"
+    pennylane_requires = ">=0.15.0"
+    version = "0.15.0"
     plugin_version = __version__
     author = "Xanadu"
 
     _capabilities = {"model": "qubit", "tensor_observables": True, "inverse_operations": True}
     _operation_map = {**QISKIT_OPERATION_MAP, **QISKIT_OPERATION_INVERSES_MAP}
-    _state_backends = {"statevector_simulator", "unitary_simulator"}
+    _state_backends = {"statevector_simulator", "unitary_simulator", "aer_simulator_statevector", "aer_simulator_unitary"}
     """set[str]: Set of backend names that define the backends
     that support returning the underlying quantum statevector"""
 
@@ -164,11 +165,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
             self.compile_backend = kwargs.pop("compile_backend")
 
         if "noise_model" in kwargs:
-            if not aer_provider or self.backend_name != "qasm_simulator":
-                raise ValueError(
-                    "Backend {} does not support noisy simulations".format(self.backend_name)
-                )
-
             noise_model = kwargs.pop("noise_model")
             self.backend.set_options(noise_model=noise_model)
 
@@ -179,13 +175,20 @@ class QiskitDevice(QubitDevice, abc.ABC):
         s = inspect.signature(self.backend.run)
         self.run_args = {}
 
+        # Specify to have a memory for hw/hw simulators
+        compile_backend = self.compile_backend or self.backend
+        memory = str(compile_backend) not in self._state_backends
+
+        if memory:
+            kwargs["memory"] = True
+
         if aer_provider:
             # Consider the remaining kwargs as keyword arguments to run
             self.run_args.update(kwargs)
 
         elif "backend_options" in s.parameters:
             # BasicAer
-            self.run_args["backend_options"] = kwargs
+            self.run_args = kwargs
 
     def set_transpile_args(self, **kwargs):
         """The transpile argument setter."""
@@ -221,12 +224,15 @@ class QiskitDevice(QubitDevice, abc.ABC):
         applied_operations.extend(rotation_circuits)
 
         for circuit in applied_operations:
-            self._circuit += circuit
+            self._circuit &= circuit
 
         if self.backend_name not in self._state_backends:
             # Add measurements if they are needed
             for qr, cr in zip(self._reg, self._creg):
                 measure(self._circuit, qr, cr)
+        else:
+            if "aer" in self.backend_name:
+                self._circuit.save_state()
 
         # These operations need to run for all devices
         qobj = self.compile()
@@ -285,7 +291,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
     def qubit_state_vector_check(self, operation, par, wires):
         """Input check for the the QubitStateVector operation."""
         if operation == "QubitStateVector":
-            if self.backend_name == "unitary_simulator":
+            if "unitary" in self.backend_name:
                 raise DeviceError(
                     "The QubitStateVector operation "
                     "is not supported on the unitary simulator backend."
@@ -312,17 +318,11 @@ class QiskitDevice(QubitDevice, abc.ABC):
         """
         compile_backend = self.compile_backend or self.backend
         compiled_circuits = transpile(self._circuit, backend=compile_backend, **self.transpile_args)
+        return compiled_circuits
 
-        # Specify to have a memory for hw/hw simulators
-        memory = str(compile_backend) not in self._state_backends
-
-        return assemble(
-            experiments=compiled_circuits, backend=compile_backend, shots=self.shots, memory=memory
-        )
-
-    def run(self, qobj):
+    def run(self, qcirc):
         """Run the compiled circuit, and query the result."""
-        self._current_job = self.backend.run(qobj, **self.run_args)
+        self._current_job = self.backend.run(qcirc, shots=self.shots, **self.run_args)
         result = self._current_job.result()
 
         if self.backend_name in self._state_backends:
@@ -337,10 +337,10 @@ class QiskitDevice(QubitDevice, abc.ABC):
         Returns:
             array[float]: size ``(2**num_wires,)`` statevector
         """
-        if self.backend_name == "statevector_simulator":
+        if "statevector" in self.backend_name:
             state = np.asarray(result.get_statevector())
 
-        elif self.backend_name == "unitary_simulator":
+        elif "unitary" in self.backend_name:
             unitary = np.asarray(result.get_unitary())
             initial_state = np.zeros([2 ** self.num_wires])
             initial_state[0] = 1

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -221,9 +221,8 @@ class QiskitDevice(QubitDevice, abc.ABC):
             # Add measurements if they are needed
             for qr, cr in zip(self._reg, self._creg):
                 measure(self._circuit, qr, cr)
-        else:
-            if "aer" in self.backend_name:
-                self._circuit.save_state()
+        elif "aer" in self.backend_name:
+            self._circuit.save_state()
 
         # These operations need to run for all devices
         compiled_circuit = self.compile()

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -169,7 +169,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
         self.set_transpile_args(**kwargs)
 
         # Get further arguments for run
-        s = inspect.signature(self.backend.run)
         self.run_args = {}
 
         # Specify to have a memory for hw/hw simulators

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -157,13 +157,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
         Args:
             kwargs (dict): keyword arguments to be set for the device
         """
-        aer_provider = str(self.provider) == "AerProvider"
-
-        # Clear Aer backend options that may have persisted since the previous
-        # device creation
-        if aer_provider:
-            self.backend.clear_options()
-
         self.compile_backend = None
         if "compile_backend" in kwargs:
             self.compile_backend = kwargs.pop("compile_backend")
@@ -186,13 +179,8 @@ class QiskitDevice(QubitDevice, abc.ABC):
         if memory:
             kwargs["memory"] = True
 
-        if aer_provider:
-            # Consider the remaining kwargs as keyword arguments to run
-            self.run_args.update(kwargs)
-
-        elif "backend_options" in s.parameters:
-            # BasicAer
-            self.run_args = kwargs
+        # Consider the remaining kwargs as keyword arguments to run
+        self.run_args.update(kwargs)
 
     def set_transpile_args(self, **kwargs):
         """The transpile argument setter."""

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -25,9 +25,8 @@ import numpy as np
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit import extensions as ex
 from qiskit.circuit.measure import measure
-from qiskit.compiler import assemble, transpile
+from qiskit.compiler import transpile
 from qiskit.converters import circuit_to_dag, dag_to_circuit
-from qiskit.providers.aer.library import save_state
 
 from pennylane import QubitDevice, DeviceError
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=0.23.4
+qiskit>=0.25
 git+https://github.com/PennyLaneAI/pennylane.git
 numpy
 networkx>=2.2;python_version>'3.5'

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 requirements = [
-    "qiskit>=0.23.4",
-    "pennylane>=0.14.0",
+    "qiskit>=0.25",
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@master",
     "numpy",
     "networkx>=2.2;python_version>'3.5'",
     # Networkx 2.4 is the final version with python 3.5 support.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,8 @@ def device(request, backend, shots):
       or (issubclass(request.param, BasicAerDevice) and "aer" in backend):
         pytest.skip("Only the AerSimulator is supported on AerDevice")
 
+    print(request.param, backend)
+
     def _device(n, device_options=None):
         if device_options is None:
             device_options = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,8 +79,6 @@ def device(request, backend, shots):
       or (issubclass(request.param, BasicAerDevice) and "aer" in backend):
         pytest.skip("Only the AerSimulator is supported on AerDevice")
 
-    print(request.param, backend)
-
     def _device(n, device_options=None):
         if device_options is None:
             device_options = {}

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -703,9 +703,9 @@ class TestConverterUtils:
 
         wires = [0]
         qc = QuantumCircuit(1)
-        qc_wires = [(q.register.name, q.index) for q in qc.qubits]
+        qc_wires = [hash(q) for q in qc.qubits]
 
-        assert map_wires(qc_wires, wires) == {0: ("q", 0)}
+        assert map_wires(qc_wires, wires) == {0: hash(qc.qubits[0])}
 
     def test_map_wires_instantiate_quantum_circuit_with_registers(self, recorder):
         """Tests the map_wires function for wires of a quantum circuit instantiated
@@ -716,31 +716,32 @@ class TestConverterUtils:
         qr2 = QuantumRegister(1)
         qr3 = QuantumRegister(1)
         qc = QuantumCircuit(qr1, qr2, qr3)
-        qc_wires = [(q.register.name, q.index) for q in qc.qubits]
+        qc_wires = [hash(q) for q in qc.qubits]
 
         mapped_wires = map_wires(qc_wires, wires)
 
         assert len(mapped_wires) == len(wires)
         assert list(mapped_wires.keys()) == wires
         for q in qc.qubits:
-            assert (q.register.name, q.index) in mapped_wires.values()
+            assert hash(q) in mapped_wires.values()
 
     def test_map_wires_provided_non_standard_order(self, recorder):
         """Tests the map_wires function for wires of non-standard order."""
 
         wires = [1, 2, 0]
         qc = QuantumCircuit(3)
-        qc_wires = [(q.register.name, q.index) for q in qc.qubits]
+        qc_wires = [hash(q) for q in qc.qubits]
 
         mapped_wires = map_wires(qc_wires, wires)
 
+        for q in qc.qubits:
+            assert hash(q) in mapped_wires.values()
+
         assert len(mapped_wires) == len(wires)
         assert set(mapped_wires.keys()) == set(wires)
-        for q in qc.qubits:
-            assert (q.register.name, q.index) in mapped_wires.values()
-        assert mapped_wires[0][1] == 2
-        assert mapped_wires[1][1] == 0
-        assert mapped_wires[2][1] == 1
+        assert mapped_wires[0] == qc_wires[2]
+        assert mapped_wires[1] == qc_wires[0]
+        assert mapped_wires[2] == qc_wires[1]
 
     def test_map_wires_exception_mismatch_in_number_of_wires(self, recorder):
         """Tests that the map_wires function raises an exception if there is a mismatch between
@@ -748,7 +749,7 @@ class TestConverterUtils:
 
         wires = [0, 1, 2]
         qc = QuantumCircuit(1)
-        qc_wires = [(q.register.name, q.index) for q in qc.qubits]
+        qc_wires = [hash(q) for q in qc.qubits]
 
         with pytest.raises(
             qml.QuantumFunctionError,

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -772,11 +772,9 @@ class TestConverterWarnings:
             with recorder:
                 quantum_circuit(params={})
 
-        # check that only one warning was raised
-        assert len(record) == 1
         # check that the message matches
         assert (
-            record[0].message.args[0]
+            record[-1].message.args[0]
             == "pennylane_qiskit.converter: The Barrier instruction is not supported by"
             " PennyLane, and has not been added to the template."
         )
@@ -839,19 +837,6 @@ class TestConverterQasm:
         assert recorder.queue[5].name == "Hadamard"
         assert recorder.queue[5].parameters == []
         assert recorder.queue[5].wires == Wires([3])
-
-        assert len(record) == 5
-        # check that the message matches
-        assert record[0].message.args[
-            0
-        ] == "pennylane_qiskit.converter: The {} instruction is not supported by" " PennyLane, and has not been added to the template.".format(
-            "Barrier"
-        )
-        assert record[1].message.args[
-            0
-        ] == "pennylane_qiskit.converter: The {} instruction is not supported by" " PennyLane, and has not been added to the template.".format(
-            "Measure"
-        )
 
     def test_qasm_file_not_found_error(self):
         """Tests that an error is propagated, when a non-existing file is specified for parsing."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,7 +34,7 @@ class TestDeviceIntegration:
     def test_incorrect_backend_wires(self):
         """Test that exception is raised if number of wires is too large"""
         with pytest.raises(ValueError, match=r"Backend 'statevector\_simulator' supports maximum"):
-            qml.device("qiskit.aer", wires=100, backend="statevector_simulator")
+            qml.device("qiskit.aer", wires=100, method="statevector")
 
     def test_args(self):
         """Test that the device requires correct arguments"""
@@ -44,7 +44,7 @@ class TestDeviceIntegration:
         with pytest.raises(
             qml.DeviceError, match="specified number of shots needs to be at least 1"
         ):
-            qml.device("qiskit.aer", backend="qasm_simulator", wires=1, shots=0)
+            qml.device("qiskit.aer", wires=1, shots=0)
 
     @pytest.mark.parametrize("d", pldevices)
     @pytest.mark.parametrize("shots", [None, 8192])
@@ -73,6 +73,11 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize("shots", [8192])
     def test_one_qubit_circuit(self, shots, d, backend, tol):
         """Integration test for the BasisState and Rot operations for non-analytic mode."""
+
+        if d[0] == "qiskit.aer" in d[0] and "aer" not in backend \
+          or d[1] == "qiskit.basic_aer" and "aer" in backend:
+            pytest.skip("Only the AerSimulator is supported on AerDevice")
+
         dev = qml.device(d[0], wires=1, backend=backend, shots=shots)
 
         a = 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,6 +20,10 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize("d", pldevices)
     def test_load_device(self, d, backend):
         """Test that the qiskit device loads correctly"""
+        if (d[0] == "qiskit.aer" and "aer" not in backend) \
+          or (d[0] == "qiskit.basicaer" and "aer" in backend):
+            pytest.skip("Only the AerSimulator is supported on AerDevice")
+
         dev = qml.device(d[0], wires=2, backend=backend, shots=1024)
         assert dev.num_wires == 2
         assert dev.shots == 1024
@@ -33,7 +37,7 @@ class TestDeviceIntegration:
 
     def test_incorrect_backend_wires(self):
         """Test that exception is raised if number of wires is too large"""
-        with pytest.raises(ValueError, match=r"Backend 'statevector\_simulator' supports maximum"):
+        with pytest.raises(ValueError, match=r"Backend 'aer_simulator\_statevector' supports maximum"):
             qml.device("qiskit.aer", wires=100, method="statevector")
 
     def test_args(self):
@@ -74,8 +78,8 @@ class TestDeviceIntegration:
     def test_one_qubit_circuit(self, shots, d, backend, tol):
         """Integration test for the BasisState and Rot operations for non-analytic mode."""
 
-        if d[0] == "qiskit.aer" in d[0] and "aer" not in backend \
-          or d[1] == "qiskit.basic_aer" and "aer" in backend:
+        if (d[0] == "qiskit.aer" and "aer" not in backend) \
+          or (d[0] == "qiskit.basicaer" and "aer" in backend):
             pytest.skip("Only the AerSimulator is supported on AerDevice")
 
         dev = qml.device(d[0], wires=1, backend=backend, shots=shots)
@@ -141,15 +145,15 @@ class TestKeywordArguments:
         cache = []
         with monkeypatch.context() as m:
             m.setattr(
-                aer.QasmSimulator, "set_options", lambda *args, **kwargs: cache.append(kwargs)
+                aer.AerSimulator, "set_options", lambda *args, **kwargs: cache.append(kwargs)
             )
             dev = qml.device("qiskit.aer", wires=2, noise_model="test value")
-        assert cache[0] == {"noise_model": "test value"}
+        assert cache[-1] == {"noise_model": "test value"}
 
     def test_invalid_noise_model(self):
         """Test that the noise model argument causes an exception to be raised
         if the backend does not support it"""
-        with pytest.raises(ValueError, match="does not support noisy simulations"):
+        with pytest.raises(AttributeError, match="field noise_model is not valid for this backend"):
             dev = qml.device("qiskit.basicaer", wires=2, noise_model="test value")
 
     def test_overflow_kwargs(self):
@@ -243,7 +247,7 @@ class TestPLOperations:
 
         dev = state_vector_device(1)
 
-        if dev.backend_name == "unitary_simulator":
+        if "unitary" in dev.backend_name:
             pytest.skip("Test only runs for backends that are not the unitary simulator.")
 
         state = init_state(1)
@@ -336,9 +340,9 @@ class TestPLTemplates:
         with monkeypatch.context() as m:
 
             # Mock the gates used in RandomLayers
-            m.setattr(qml.templates.layers.random, "RX", mock_func)
-            m.setattr(qml.templates.layers.random, "RY", mock_func)
-            m.setattr(qml.templates.layers.random, "RZ", mock_func)
+            m.setattr(qml, "RX", mock_func)
+            m.setattr(qml, "RY", mock_func)
+            m.setattr(qml, "RZ", mock_func)
 
             @qml.qnode(dev)
             def circuit(phi=None):
@@ -465,13 +469,13 @@ class TestNoise:
         bit_flip = aer.noise.pauli_error([("X", 1), ("I", 0)])
 
         # Create a noise model where the RX operation always flips the bit
-        noise_model.add_all_qubit_quantum_error(bit_flip, ["rx"])
+        noise_model.add_all_qubit_quantum_error(bit_flip, ["z"])
 
         dev = qml.device("qiskit.aer", wires=2, noise_model=noise_model)
 
         @qml.qnode(dev)
         def circuit():
-            qml.RX(0, wires=[0])
+            qml.PauliZ(wires=[0])
             return qml.expval(qml.PauliZ(wires=0))
 
         assert circuit() == -1

--- a/tests/test_inverses.py
+++ b/tests/test_inverses.py
@@ -30,7 +30,7 @@ class TestInverses:
 
         op = getattr(qml.ops, name)
 
-        dev = qml.device("qiskit.aer", backend="statevector_simulator", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
 
         @qml.qnode(dev)
         def circuit():
@@ -53,7 +53,7 @@ class TestInverses:
 
         op = getattr(qml.ops, name)
 
-        dev = qml.device("qiskit.aer", backend="statevector_simulator", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
 
         assert dev.supports_operation(name)
 
@@ -76,7 +76,7 @@ class TestInverses:
 
         op = getattr(qml.ops, name)
 
-        dev = qml.device("qiskit.aer", backend="statevector_simulator", wires=3, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=3, shots=None)
 
         assert dev.supports_operation(name)
 
@@ -129,7 +129,7 @@ class TestInverses:
     def test_supported_gate_inverse_single_wire_with_parameters(self, name, par, expected_output):
         """Test the inverse of single gates with parameters"""
 
-        dev = qml.device("qiskit.aer", backend="statevector_simulator", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
 
         op = getattr(qml.ops, name)
 
@@ -182,7 +182,7 @@ class TestInverses:
     def test_supported_gate_inverse_two_wires_with_parameters(self, name, par, expected_output):
         """Tests the inverse of supported gates that act on two wires that are parameterized"""
 
-        dev = qml.device("qiskit.aer", backend="statevector_simulator", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
 
         op = getattr(qml.ops, name)
 
@@ -210,7 +210,7 @@ class TestInverses:
     def test_unsupported_gate_inverses(self, name, par, expected_output):
         """Test the inverse of single gates with parameters"""
 
-        dev = qml.device("qiskit.aer", backend="statevector_simulator", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
 
         op = getattr(qml.ops, name)
 
@@ -225,7 +225,7 @@ class TestInverses:
     def test_s_gate_inverses(self, par):
         """Tests the inverse of the S gate"""
 
-        dev = qml.device("qiskit.aer", backend="statevector_simulator", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
 
         expected_output = -0.5 * 1j * cmath.exp(-1j * par) * (-1 + cmath.exp(2j * par))
 
@@ -242,7 +242,7 @@ class TestInverses:
     def test_t_gate_inverses(self, par):
         """Tests the inverse of the T gate"""
 
-        dev = qml.device("qiskit.aer", backend="statevector_simulator", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
 
         expected_output = -math.sin(par) / math.sqrt(2)
 

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -20,14 +20,13 @@ class TestProbabilities:
     def test_probability_no_results(self):
         """Test that the probabilities function returns
         None if no job has yet been run."""
-        dev = AerDevice(backend="statevector_simulator", wires=1, shots=None)
+        dev = AerDevice(backend="aer_simulator_statevector", wires=1, shots=None)
         assert dev.probability() is None
 
 
 @pytest.mark.parametrize("wires", [1, 2, 3])
 @pytest.mark.parametrize("shots", [None])
 @pytest.mark.parametrize("device_options", test_device_options)
-@pytest.mark.transpile_args_test
 class TestTranspilationOptionInitialization:
     """Tests for passing the transpilation options to qiskit at time of device
     initialization."""
@@ -52,6 +51,8 @@ class TestAnalyticWarningHWSimulator:
     def test_warning_raised_for_hardware_backend_analytic_expval(self, hardware_backend, recorder):
         """Tests that a warning is raised if the analytic attribute is true on
         hardware simulators when calculating the expectation"""
+        if "aer" in hardware_backend:
+            pytest.skip("Not supported on basicaer")
 
         with pytest.warns(UserWarning) as record:
             dev = qml.device("qiskit.basicaer", backend=hardware_backend, wires=2, shots=None)
@@ -71,6 +72,8 @@ class TestAnalyticWarningHWSimulator:
     ):
         """Tests that no warning is raised if the analytic attribute is true on
         statevector simulators when calculating the expectation"""
+        if "aer" in statevector_backend:
+            pytest.skip("Not supported on basicaer")
 
         dev = qml.device("qiskit.basicaer", backend=statevector_backend, wires=2, shots=None)
 
@@ -91,7 +94,7 @@ class TestAerBackendOptions:
         noise_model.add_all_qubit_quantum_error(bit_flip, ["rx"])
 
         dev = qml.device("qiskit.aer", wires=2, noise_model=noise_model)
-        assert "noise_model" in dev.backend.options
+        assert dev.backend.options.get("noise_model") is not None
 
         dev2 = qml.device("qiskit.aer", wires=2)
-        assert "noise_model" not in dev2.backend.options
+        assert dev2.backend.options.get("noise_model") is None


### PR DESCRIPTION
While the tests are passing, there are a _huge_ number of warnings:

The first set of warnings are due to `qasm_simulator`, `unitary_simulator`, and `statevector_simulator` being deprecated, but I have modified `conftest.py` so that they are never used with `qiskit.aer`... so I can't tell why they are still being emitted 🤔 

```
tests/test_integration.py: 31 tests with warnings
  /qiskit/providers/aer/backends/qasm_simulator.py:331: PendingDeprecationWarning: The `QasmSimulator` backend will be deprecated in the future. It has been superseded by the `AerSimulator` backend.
    ' backend.', PendingDeprecationWarning)

tests/test_integration.py: 31 tests with warnings
  /qiskit/providers/aer/backends/statevector_simulator.py:156: PendingDeprecationWarning: The `StatevectorSimulator` backend will be deprecated in the future. It has been superseded by the `AerSimulator` backend. To obtain legacy functionality initalize with `AerSimulator(method="statevector")` and append run circuits with the `save_state` instruction.
    ' with the `save_state` instruction.', PendingDeprecationWarning)

tests/test_integration.py: 30 tests with warnings
 /qiskit/providers/aer/backends/unitary_simulator.py:155: PendingDeprecationWarning: The `UnitarySimulator` backend will be deprecated in the future. It has been superseded by the `AerSimulator` backend. To obtain legacy functionality initalize with `AerSimulator(method="unitary")` and append run circuits with the `save_state` instruction.
    ' with the `save_state` instruction.', PendingDeprecationWarning)
```

The next one I am also not sure about:

```
tests/test_integration.py: 13 tests with warnings
  /pennylane_qiskit/qiskit_device.py:325: UserWarning: Option verbose is not used by this backend
    self._current_job = self.backend.run(qcirc, shots=self.shots, **self.run_args)
```

Finally, I think this requires the following lines in `converter.py` to be updated @antalszava?

```
tests/test_integration.py: 20 tests with warnings
  /pennylane_qiskit/converter.py:174: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.
    qc_wires = [(q.register.name, q.index) for q in quantum_circuit.qubits]

tests/test_integration.py: 12 tests with warnings
  /pennylane_qiskit/converter.py:183: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.
    operation_wires = [wire_map[(qubit.register.name, qubit.index)] for qubit in op[1]]
```