### PR TITLE
Using hash instead of tuple

### DIFF
--- a/doc/devices/aer.rst
+++ b/doc/devices/aer.rst
@@ -63,7 +63,7 @@ Backend Methods and Options
 
 This ``AerSimulator`` backend has several available methods, which
 can be passed via the ``method`` keyword argument. For example
-``'automatica'``, ``'statevector'``, and ``'unitary'``.
+``'automatic'``, ``'statevector'``, and ``'unitary'``.
 
 .. code-block:: python
 

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -171,11 +171,7 @@ def load(quantum_circuit: QuantumCircuit):
         qc = _check_circuit_and_bind_parameters(quantum_circuit, params, var_ref_map)
 
         # Wires from a qiskit circuit are unique w.r.t. a register name and a qubit index
-        qc_wires = [
-            (reg.name, qubit_ind)
-            for reg in quantum_circuit.qregs
-            for qubit_ind, _ in enumerate(reg)
-        ]
+        qc_wires = [hash(q) for q in qc.qubits]
 
         wire_map = map_wires(wires, qc_wires)
 
@@ -184,7 +180,7 @@ def load(quantum_circuit: QuantumCircuit):
 
             instruction_name = op[0].__class__.__name__
 
-            operation_wires = [wire_map[(qubit.register.name, qubit.index)] for qubit in op[1]]
+            operation_wires = [wire_map[hash(qubit)] for qubit in op[1]]
 
             # New Qiskit gates that are not natively supported by PL (identical
             # gates exist with a different name)

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -170,7 +170,7 @@ def load(quantum_circuit: QuantumCircuit):
         var_ref_map = _extract_variable_refs(params)
         qc = _check_circuit_and_bind_parameters(quantum_circuit, params, var_ref_map)
 
-        # Wires from a qiskit circuit are unique w.r.t. a register name and a qubit index
+        # Wires from a qiskit circuit have unique IDs, so their hashes are unique too
         qc_wires = [hash(q) for q in qc.qubits]
 
         wire_map = map_wires(wires, qc_wires)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -703,9 +703,9 @@ class TestConverterUtils:
 
         wires = [0]
         qc = QuantumCircuit(1)
-        qc_wires = [(q.register.name, q.index) for q in qc.qubits]
+        qc_wires = [hash(q) for q in qc.qubits]
 
-        assert map_wires(qc_wires, wires) == {0: ("q", 0)}
+        assert map_wires(qc_wires, wires) == {0: hash(qc.qubits[0])}
 
     def test_map_wires_instantiate_quantum_circuit_with_registers(self, recorder):
         """Tests the map_wires function for wires of a quantum circuit instantiated
@@ -716,31 +716,32 @@ class TestConverterUtils:
         qr2 = QuantumRegister(1)
         qr3 = QuantumRegister(1)
         qc = QuantumCircuit(qr1, qr2, qr3)
-        qc_wires = [(q.register.name, q.index) for q in qc.qubits]
+        qc_wires = [hash(q) for q in qc.qubits]
 
         mapped_wires = map_wires(qc_wires, wires)
 
         assert len(mapped_wires) == len(wires)
         assert list(mapped_wires.keys()) == wires
         for q in qc.qubits:
-            assert (q.register.name, q.index) in mapped_wires.values()
+            assert hash(q) in mapped_wires.values()
 
     def test_map_wires_provided_non_standard_order(self, recorder):
         """Tests the map_wires function for wires of non-standard order."""
 
         wires = [1, 2, 0]
         qc = QuantumCircuit(3)
-        qc_wires = [(q.register.name, q.index) for q in qc.qubits]
+        qc_wires = [hash(q) for q in qc.qubits]
 
         mapped_wires = map_wires(qc_wires, wires)
 
+        for q in qc.qubits:
+            assert hash(q) in mapped_wires.values()
+
         assert len(mapped_wires) == len(wires)
         assert set(mapped_wires.keys()) == set(wires)
-        for q in qc.qubits:
-            assert (q.register.name, q.index) in mapped_wires.values()
-        assert mapped_wires[0][1] == 2
-        assert mapped_wires[1][1] == 0
-        assert mapped_wires[2][1] == 1
+        assert mapped_wires[0] == qc_wires[2]
+        assert mapped_wires[1] == qc_wires[0]
+        assert mapped_wires[2] == qc_wires[1]
 
     def test_map_wires_exception_mismatch_in_number_of_wires(self, recorder):
         """Tests that the map_wires function raises an exception if there is a mismatch between
@@ -748,7 +749,7 @@ class TestConverterUtils:
 
         wires = [0, 1, 2]
         qc = QuantumCircuit(1)
-        qc_wires = [(q.register.name, q.index) for q in qc.qubits]
+        qc_wires = [hash(q) for q in qc.qubits]
 
         with pytest.raises(
             qml.QuantumFunctionError,


### PR DESCRIPTION
New qiskit is deprecating getting the register name from a qubit.  We therefore need a better way of uniquely identifying qubits and their `(register, index)` combination.   Qiskit `Bit`'s have their own hash defined on the tuple of register name and index, and so will uniquely define each bit.

Though these bits will be harder to debug and read, the hash will be sufficiently unique per qubit to allow matching up qiskit qubits and PL wires.