### PR TITLE
switch input order for map_wires

### DIFF
--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -100,13 +100,13 @@ def _check_circuit_and_bind_parameters(
     return quantum_circuit.bind_parameters(params)
 
 
-def map_wires(wires: list, qc_wires: list) -> dict:
+def map_wires(qc_wires: list, wires: list) -> dict:
     """Utility function mapping the wires specified in a quantum circuit with the wires
     specified by the user for the template.
 
     Args:
-        wires (list): wires specified for the template
         qc_wires (list): wires from the converted quantum circuit
+        wires (list): wires specified for the template
 
     Returns:
         dict[int, int]: map from quantum circuit wires to the user defined wires
@@ -173,7 +173,7 @@ def load(quantum_circuit: QuantumCircuit):
         # Wires from a qiskit circuit have unique IDs, so their hashes are unique too
         qc_wires = [hash(q) for q in qc.qubits]
 
-        wire_map = map_wires(wires, qc_wires)
+        wire_map = map_wires(qc_wires, wires)
 
         # Processing the dictionary of parameters passed
         for op in qc.data:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -705,7 +705,7 @@ class TestConverterUtils:
         qc = QuantumCircuit(1)
         qc_wires = [hash(q) for q in qc.qubits]
 
-        assert map_wires(qc_wires, wires) == {0: hash(qc.qubits[0])}
+        assert map_wires(wires, qc_wires) == {0: hash(qc.qubits[0])}
 
     def test_map_wires_instantiate_quantum_circuit_with_registers(self, recorder):
         """Tests the map_wires function for wires of a quantum circuit instantiated
@@ -718,7 +718,7 @@ class TestConverterUtils:
         qc = QuantumCircuit(qr1, qr2, qr3)
         qc_wires = [hash(q) for q in qc.qubits]
 
-        mapped_wires = map_wires(qc_wires, wires)
+        mapped_wires = map_wires(wires, qc_wires)
 
         assert len(mapped_wires) == len(wires)
         assert list(mapped_wires.keys()) == wires
@@ -732,7 +732,7 @@ class TestConverterUtils:
         qc = QuantumCircuit(3)
         qc_wires = [hash(q) for q in qc.qubits]
 
-        mapped_wires = map_wires(qc_wires, wires)
+        mapped_wires = map_wires(wires, qc_wires)
 
         for q in qc.qubits:
             assert hash(q) in mapped_wires.values()
@@ -756,7 +756,7 @@ class TestConverterUtils:
             match="The specified number of wires - {} - does not match "
             "the number of wires the loaded quantum circuit acts on.".format(len(wires)),
         ):
-            map_wires(wires, qc_wires)
+            map_wires(qc_wires, wires)
 
 
 class TestConverterWarnings:


### PR DESCRIPTION
Issue #134 

Previously in `converter.py`, the function `map_wires` took in arguments of the order `values, keys` to create a dictionary from `keys` to `values`.

This was conterintuitive, so I have switched the order.