### PR TITLE
Parameter expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Improvements
 
+* The plugin can now load Qiskit circuits with more complicated ``ParameterExpression`` variables.
+
 ### Documentation
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Improvements
 
 * The plugin can now load Qiskit circuits with more complicated ``ParameterExpression`` variables.
+[(#139)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/139)
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Vincent Wong
+Christina Lee, Vincent Wong
 
 # Release 0.15.0
 

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -199,10 +199,10 @@ def load(quantum_circuit: QuantumCircuit):
                     _check_parameter_bound(p, var_ref_map)
 
                     if isinstance(p, ParameterExpression):
-                        if p.parameters: # non-empty set = has unbound parameters
+                        if p.parameters:  # non-empty set = has unbound parameters
                             ordered_params = tuple(p.parameters)
 
-                            f = lambdify(ordered_params, p._symbol_expr, 'numpy')
+                            f = lambdify(ordered_params, p._symbol_expr, modules=qml.numpy)
                             f_args = []
                             for i_ordered_params in ordered_params:
                                 f_args.append(var_ref_map.get(i_ordered_params))
@@ -212,7 +212,9 @@ def load(quantum_circuit: QuantumCircuit):
                     else:
                         pl_parameters.append(p)
 
-                execute_supported_operation(inv_map[instruction_name], pl_parameters, operation_wires)
+                execute_supported_operation(
+                    inv_map[instruction_name], pl_parameters, operation_wires
+                )
 
             elif instruction_name == "SdgGate":
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 qiskit>=0.25
 pennylane>=0.15
 numpy
+sympy
 networkx>=2.2;python_version>'3.5'
 networkx>=2.2,<2.4;python_version=='3.5'

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1076,8 +1076,8 @@ class TestConverterIntegration:
 
         assert np.allclose(res, expected, **tol)
 
-    def test_parameterexpression(self):
-        """Tests for functions of parameters passed to qiskit gate"""
+    def test_parameter_expression(self):
+        """Tests the output and the gradient of a QNode that contains loaded Qiskit gates taking functions of parameters as argument"""
 
         a = Parameter("a")
         b = Parameter("b")


### PR DESCRIPTION
Closes Issue #129 

This improvement allows the plugin to load circuits with more general parameter expressions.

For example,

```python
from qiskit import QuantumCircuit
from qiskit.circuit import Parameter
from pennylane_qiskit import load

a = Parameter("a")
b = Parameter("b")

qc = QuantumCircuit(1,1)
qc.rz(a*b, [0])

dev  = qml.device('default.qubit', wires=1)

@qml.qnode(dev)
def circ(x, y):
    load(qc)(params={a: x, b: y}, wires=(0,))
    return qml.expval(qml.PauliZ(0))
````

Currently, the above code would raise an error.

I also add `sympy` to the requirements, as it is explicitly used.  Qiskit already has sympy as a dependency, so this does not add any cost to the requirements.