### PR TITLE
Pin to PennyLane 0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@
   PennyLane v0.16 to the Qiskit devices.
   [(#137)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/137)
 
+### Breaking changes
+
+* Deprecated Python 3.6.
+  [(#140)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/140)
+
 ### Improvements
 
 * The plugin can now load Qiskit circuits with more complicated ``ParameterExpression`` variables.
-[(#139)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/139)
+  [(#139)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/139)
 
 ### Contributors
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 qiskit>=0.25
-git+https://github.com/PennyLaneAI/pennylane.git@v0.16.0-rc0
+pennylane>=0.16
 numpy
 sympy
 networkx>=2.2;python_version>'3.5'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.rst", "r") as fh:
 
 requirements = [
     "qiskit>=0.25",
-    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@v0.16.0-rc0",
+    "pennylane>=0.16",
     "numpy",
     "networkx>=2.2",
 ]


### PR DESCRIPTION
Pins the requirement to `pennylane>=0.16` before releasing the plugin.