### PR TITLE
Update `qml.QubitUnitary` error message in test

### DIFF
--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -256,7 +256,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             mapped_operation = self._operation_map[operation]
 
-            self.qubit_unitary_check(operation, par, device_wires)
             self.qubit_state_vector_check(operation, par, device_wires)
 
             qregs = [self._reg[i] for i in device_wires.labels]
@@ -289,16 +288,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             if len(par[0]) != 2 ** len(wires):
                 raise ValueError("State vector must be of length 2**wires.")
-
-    @staticmethod
-    def qubit_unitary_check(operation, par, wires):
-        """Input check for the the QubitUnitary operation."""
-        if operation == "QubitUnitary":
-            if len(par[0]) != 2 ** len(wires):
-                raise ValueError(
-                    "Unitary matrix must be of shape (2**wires,\
-                        2**wires)."
-                )
 
     def compile(self):
         """Compile the quantum circuit to target the provided compile_backend.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 qiskit>=0.25
-pennylane>=0.16
+git+https://github.com/PennyLaneAI/pennylane.git@master
 numpy
 sympy
 networkx>=2.2;python_version>'3.5'

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -212,7 +212,7 @@ class TestNonAnalyticApply:
         dev = device(2)
         state = np.array([[0, 123.432], [-0.432, 023.4]])
 
-        with pytest.raises(ValueError, match=r"Unitary matrix must be of shape"):
+        with pytest.raises(ValueError, match=r"Input unitary must be of shape"):
             dev.apply([qml.QubitUnitary(state, wires=[0, 1])])
 
     @pytest.mark.parametrize("operation", single_qubit_operations)


### PR DESCRIPTION
This change was required due to an updated error message in PennyLane core from https://github.com/PennyLaneAI/pennylane/pull/1439