### PR TITLE
Update tests due to the deprecated `qml.sample` usage when `shots=None`

### DIFF
--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -31,7 +31,8 @@ class TestExpval:
             rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()],
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1), dev.expval(O2)])
         assert np.allclose(res, np.array([1, 1]), **tol)
@@ -47,7 +48,8 @@ class TestExpval:
             rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()],
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1), dev.expval(O2)])
         assert np.allclose(res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), **tol)
@@ -63,7 +65,8 @@ class TestExpval:
             rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()],
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1), dev.expval(O2)])
         assert np.allclose(res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)]), **tol)
@@ -79,7 +82,8 @@ class TestExpval:
             rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()],
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1), dev.expval(O2)])
         assert np.allclose(res, np.array([0, -np.cos(theta) * np.sin(phi)]), **tol)
@@ -95,7 +99,8 @@ class TestExpval:
             rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()],
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1), dev.expval(O2)])
         expected = np.array(
@@ -113,7 +118,8 @@ class TestExpval:
             [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1])],
             rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()],
         )
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1), dev.expval(O2)])
 
@@ -145,7 +151,8 @@ class TestExpval:
             [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1])],
             rotations=[*O1.diagonalizing_gates()],
         )
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
 
         res = np.array([dev.expval(O1)])
 
@@ -184,7 +191,9 @@ class TestTensorExpval:
             rotations=obs.diagonalizing_gates(),
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
+
         res = dev.expval(obs)
 
         expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
@@ -208,7 +217,9 @@ class TestTensorExpval:
             rotations=obs.diagonalizing_gates(),
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
+
         res = dev.expval(obs)
 
         expected = np.cos(varphi) * np.cos(phi)
@@ -232,7 +243,9 @@ class TestTensorExpval:
             rotations=obs.diagonalizing_gates(),
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
+
         res = dev.expval(obs)
         expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
 
@@ -264,7 +277,9 @@ class TestTensorExpval:
             rotations=obs.diagonalizing_gates(),
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
+
         res = dev.expval(obs)
         expected = 0.5 * (
             -6 * np.cos(theta) * (np.cos(varphi) + 1)
@@ -302,7 +317,9 @@ class TestTensorExpval:
             rotations=obs.diagonalizing_gates(),
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
+
         res = dev.expval(obs)
         expected = 0.25 * (
             -30
@@ -339,7 +356,9 @@ class TestTensorExpval:
             rotations=obs.diagonalizing_gates(),
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
+
         res = dev.expval(obs)
 
         a = A[0, 0]

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -35,7 +35,8 @@ class TestVar:
             rotations=[*observable.diagonalizing_gates()],
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
 
         var = dev.var(observable)
         expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
@@ -59,7 +60,8 @@ class TestVar:
             rotations=[*observable.diagonalizing_gates()],
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
 
         var = dev.var(observable)
         expected = 0.5 * (
@@ -93,7 +95,9 @@ class TestTensorVar:
             rotations=obs.diagonalizing_gates(),
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
+
         res = dev.var(obs)
 
         expected = (
@@ -123,7 +127,9 @@ class TestTensorVar:
             rotations=obs.diagonalizing_gates(),
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
+
         res = dev.var(obs)
 
         expected = (
@@ -160,7 +166,9 @@ class TestTensorVar:
             rotations=obs.diagonalizing_gates(),
         )
 
-        dev._samples = dev.generate_samples()
+        if shots is not None:
+            dev._samples = dev.generate_samples()
+
         res = dev.var(obs)
 
         expected = (


### PR DESCRIPTION
Some test cases needed adjustment due to: https://github.com/PennyLaneAI/pennylane/pull/1522 as the plugin test matrix is failing in some cases.