### PR TITLE
Remove adding a verbose option to the run arguments

### DIFF
--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -125,9 +125,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
         self._backend = None
 
-        if "verbose" not in kwargs:
-            kwargs["verbose"] = False
-
         self.provider = provider
         self.backend_name = backend
         self._capabilities["backend"] = [b.name() for b in self.provider.backends()]


### PR DESCRIPTION
**Context**

In `QiskitDevice`, a `verbose` option is being added by default to the keyword arguments to be passed to the backend. This has caused warnings when submitting jobs to IBMQ.

The lines that set the verbose to false have been added a while back in https://github.com/PennyLaneAI/pennylane-qiskit/pull/44. Likely, this used to be a valid backend option, however, at the moment there Qiskit doesn't seem to support it.

**Changes**

Removes the addition of the verbose option.

**Related issues**

#145 