### PR TITLE
Define the `QiskitDevice.batch_execute` method

### DIFF
--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Xanadu Quantum Technologies Inc.
+# Copyright 2019-2021 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -322,7 +322,11 @@ class QiskitDevice(QubitDevice, abc.ABC):
             array[float]: size ``(2**num_wires,)`` statevector
         """
         if "statevector" in self.backend_name:
-            state = np.asarray(result.get_statevector(experiment))
+            #print(result, experiment)
+            if experiment is not None:
+                state = np.asarray(result.get_statevector(experiment))
+            else:
+                state = np.asarray(result.get_statevector())
 
         elif "unitary" in self.backend_name:
             unitary = np.asarray(result.get_unitary(experiment))

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -210,7 +210,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
             operations (list[~.Operation]): operations to apply to the device
 
         Keyword args:
-            rotations (list[~.Operation]): operations that rotate the circuit
+            rotations (list[~.Operation]): Operations that rotate the circuit
                 pre-measurement into the eigenbasis of the observables.
         """
         rotations = kwargs.get("rotations", [])
@@ -307,8 +307,8 @@ class QiskitDevice(QubitDevice, abc.ABC):
         backend.
         """
         compile_backend = self.compile_backend or self.backend
-        circuit_objs = transpile(self._circuit, backend=compile_backend, **self.transpile_args)
-        return circuit_objs
+        compiled_circuits = transpile(self._circuit, backend=compile_backend, **self.transpile_args)
+        return compiled_circuits
 
     def run(self, qcirc):
         """Run the compiled circuit, and query the result."""

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -322,11 +322,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
             array[float]: size ``(2**num_wires,)`` statevector
         """
         if "statevector" in self.backend_name:
-            #print(result, experiment)
-            if experiment is not None:
-                state = np.asarray(result.get_statevector(experiment))
-            else:
-                state = np.asarray(result.get_statevector())
+            state = np.asarray(result.get_statevector(experiment))
 
         elif "unitary" in self.backend_name:
             unitary = np.asarray(result.get_unitary(experiment))

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -347,7 +347,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         Note that PennyLane uses the convention :math:`|q_0,q_1,\dots,q_{N-1}\rangle` where
         :math:`q_0` is the most significant bit.
 
-        Keyword Args:
+        Args:
             circuit (str): the name of the circuit to get the state for
 
         Returns:

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -323,8 +323,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
         Args:
             result (qiskit.Result): result object
-
-        Keyword Args:
             experiment (str): the name of the experiment to get the state for
 
         Returns:

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -380,7 +380,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
     def batch_execute(self, circuits):
 
-        circuit_objs = []
+        compiled_circuits = []
 
         # Compile each of the objects
         for circuit in circuits:
@@ -389,17 +389,17 @@ class QiskitDevice(QubitDevice, abc.ABC):
             self.reset()
             self.create_circuit_object(circuit.operations, rotations=circuit.diagonalizing_gates)
 
-            compiled_circuit = self.compile()
-            compiled_circuit.name = f"circ{len(circuit_objs)}"
-            circuit_objs.append(compiled_circuit)
+            compiled_circ = self.compile()
+            compiled_circ.name = f"circ{len(compiled_circuits)}"
+            compiled_circuits.append(compiled_circ)
 
         # Send the batch of circuit objects using backend.run
-        self._current_job = self.backend.run(circuit_objs, shots=self.shots, **self.run_args)
+        self._current_job = self.backend.run(compiled_circuits, shots=self.shots, **self.run_args)
         result = self._current_job.result()
 
         # Process the sample for each circuit object
         results = []
-        for circuit, circuit_obj in zip(circuits, circuit_objs):
+        for circuit, circuit_obj in zip(circuits, compiled_circuits):
 
             if self.backend_name in self._state_backends:
                 self._state = self._get_state(result, experiment=circuit_obj)

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -315,6 +315,9 @@ class QiskitDevice(QubitDevice, abc.ABC):
         Args:
             result (qiskit.Result): result object
 
+        Keyword Args:
+            experiment (str): the name of the experiment to get the state for
+
         Returns:
             array[float]: size ``(2**num_wires,)`` statevector
         """
@@ -332,6 +335,17 @@ class QiskitDevice(QubitDevice, abc.ABC):
         return state.reshape([2] * self.num_wires).T.flatten()
 
     def generate_samples(self, circuit=None):
+        r"""Returns the computational basis samples generated for all wires.
+
+        Note that PennyLane uses the convention :math:`|q_0,q_1,\dots,q_{N-1}\rangle` where
+        :math:`q_0` is the most significant bit.
+
+        Keyword Args:
+            circuit (str): the name of the circuit to get the state for
+
+        Returns:
+             array[complex]: array of samples in the shape ``(dev.shots, dev.num_wires)``
+        """
 
         # branch out depending on the type of backend
         if self.backend_name in self._state_backends:
@@ -358,10 +372,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
     def batch_execute(self, circuits):
         if not isinstance(circuits, list):
             circuits = [circuits]
-
-        #if self.backend_name in self._state_backends:
-            # TODO: how for statevector sims.?
-        #    return super().batch_execute(circuits)
 
         circuit_objs = []
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -370,8 +370,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
         return prob
 
     def batch_execute(self, circuits):
-        if not isinstance(circuits, list):
-            circuits = [circuits]
 
         circuit_objs = []
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -382,8 +382,9 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
         compiled_circuits = []
 
-        # Compile each of the objects
+        # Compile each circuit object
         for circuit in circuits:
+
             # We need to reset the device here, else it will
             # not start the next computation in the zero state
             self.reset()
@@ -397,7 +398,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         self._current_job = self.backend.run(compiled_circuits, shots=self.shots, **self.run_args)
         result = self._current_job.result()
 
-        # Process the sample for each circuit object
+        # Compute statistics using the state and/or samples
         results = []
         for circuit, circuit_obj in zip(circuits, compiled_circuits):
 

--- a/tests/test_ibmq.py
+++ b/tests/test_ibmq.py
@@ -14,6 +14,8 @@ from pennylane_qiskit import qiskit_device as qiskit_device
 
 @pytest.fixture
 def token():
+    """A fixture loading the IBMQ token from the IBMQX_TOKEN_TEST environment
+    variable."""
     t = os.getenv("IBMQX_TOKEN_TEST", None)
 
     if t is None:
@@ -131,6 +133,7 @@ def test_custom_provider_hub_group_project(monkeypatch):
 
 
 def test_load_from_disk(token):
+    """Test loading the account credentials and the device from disk."""
     IBMQ.save_account(token)
     dev = IBMQDevice(wires=1)
     assert dev.provider.credentials.is_ibmq()
@@ -138,6 +141,7 @@ def test_load_from_disk(token):
 
 
 def test_account_error(monkeypatch):
+    """Test that an error is raised if there is no active IBMQ account."""
 
     # Token is passed such that the test is skipped if no token was provided
     with pytest.raises(IBMQAccountError, match="No active IBM Q account"):
@@ -148,6 +152,7 @@ def test_account_error(monkeypatch):
 
 @pytest.mark.parametrize("shots", [1000])
 def test_simple_circuit(token, tol, shots):
+    """Test executing a simple circuit submitted to IBMQ."""
     IBMQ.enable_account(token)
     dev = IBMQDevice(wires=2, backend="ibmq_qasm_simulator", shots=shots)
 
@@ -167,7 +172,9 @@ def test_simple_circuit(token, tol, shots):
 
 
 @pytest.mark.parametrize("shots", [1000])
-def test_simple_batched_circuit(token, tol, shots, mocker):
+def test_simple_circuit_with_batch_params(token, tol, shots, mocker):
+    """Test that executing a simple circuit with batched parameters is
+    submitted to IBMQ once."""
     IBMQ.enable_account(token)
     dev = IBMQDevice(wires=2, backend="ibmq_qasm_simulator", shots=shots)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -508,13 +508,13 @@ class TestBatchExecution:
         b = np.linspace(0, 0.123, batch_dim)
         c = np.linspace(0, 0.987, batch_dim)
 
-        spy = mocker.spy(QiskitDevice, "batch_execute")
+        spy1 = mocker.spy(QiskitDevice, "batch_execute")
+        spy2 = mocker.spy(dev.backend, "run")
 
         @qml.batch_params
         @qml.qnode(dev)
         def circuit(x, y, z):
             """Reference QNode"""
-            qml.BasisState(np.array([1]), wires=0)
             qml.Hadamard(wires=0)
             qml.Rot(x, y, z, wires=0)
             return qml.expval(qml.PauliZ(0))
@@ -522,4 +522,5 @@ class TestBatchExecution:
         assert np.allclose(circuit(a, b, c), np.cos(a) * np.sin(b), **tol)
 
         # Check that QiskitDevice.batch_execute was called
-        assert spy.call_count == 1
+        assert spy1.call_count == 1
+        assert spy2.call_count == 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -528,9 +528,9 @@ class TestBatchExecution:
 
     @pytest.mark.parametrize("d", pldevices)
     @pytest.mark.parametrize("shots", [None, 8192])
-    def test_gradients_batch_params(self, shots, d, backend, tol, mocker):
-        """Test that devices provide correct result for a simple circuit using
-        the batch_params transform."""
+    def test_batch_execute_parameter_shift(self, shots, d, backend, tol, mocker):
+        """Test that devices provide correct result computing the gradient of a
+        circuit using the parameter-shift rule and the batch execution pipeline."""
         if (d[0] == "qiskit.aer" and "aer" not in backend) \
           or (d[0] == "qiskit.basicaer" and "aer" in backend):
             pytest.skip("Only the AerSimulator is supported on AerDevice")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -515,6 +515,7 @@ class TestBatchExecution:
         @qml.qnode(dev)
         def circuit(x, y, z):
             """Reference QNode"""
+            qml.PauliX(0)
             qml.Hadamard(wires=0)
             qml.Rot(x, y, z, wires=0)
             return qml.expval(qml.PauliZ(0))

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -3,6 +3,7 @@ import pytest
 
 import pennylane as qml
 from pennylane_qiskit import AerDevice
+from pennylane_qiskit.qiskit_device import QiskitDevice
 import qiskit.providers.aer.noise as noise
 
 test_transpile_options = [
@@ -98,3 +99,82 @@ class TestAerBackendOptions:
 
         dev2 = qml.device("qiskit.aer", wires=2)
         assert dev2.backend.options.get("noise_model") is None
+
+@pytest.mark.parametrize("shots", [None])
+class TestBatchExecution:
+    """Tests for the batch_execute method."""
+
+    with qml.tape.QuantumTape() as tape1:
+        qml.PauliX(wires=0)
+        qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliZ(wires=1))
+
+    with qml.tape.JacobianTape() as tape2:
+        qml.PauliX(wires=0)
+        qml.expval(qml.PauliZ(wires=0))
+
+    @pytest.mark.parametrize("n_tapes", [1, 2, 3])
+    def test_calls_to_execute(self, device, n_tapes, mocker):
+        """Tests that only the device's dedicated batch execute method is
+        called and not the general execute method."""
+
+        dev = device(2)
+        spy = mocker.spy(QiskitDevice, "execute")
+
+        tapes = [self.tape1] * n_tapes
+        dev.batch_execute(tapes)
+
+        # Check that QiskitDevice.execute was not called
+        assert spy.call_count == 0
+
+    @pytest.mark.parametrize("n_tapes", [1, 2, 3])
+    def test_calls_to_reset(self, n_tapes, mocker, device):
+        """Tests that the device's reset method is called the correct number of
+        times."""
+
+        dev = device(2)
+        spy = mocker.spy(QiskitDevice, "reset")
+
+        tapes = [self.tape1] * n_tapes
+        dev.batch_execute(tapes)
+
+        assert spy.call_count == n_tapes
+
+    def test_result(self, device, tol):
+        """Tests that the result has the correct shape and entry types."""
+        dev = device(2)
+        tapes = [self.tape1, self.tape2]
+        res = dev.batch_execute(tapes)
+
+        # We're calling device methods directly, need to reset before the next
+        # execution
+        dev.reset()
+        tape1_expected = dev.execute(self.tape1)
+
+        dev.reset()
+        tape2_expected = dev.execute(self.tape2)
+
+        assert len(res) == 2
+        assert np.allclose(
+            res[0], tape1_expected, atol=0
+        )
+
+        dev.reset() # We're calling device methods directly, need to reset
+        assert np.allclose(
+            res[1], tape2_expected, atol=0
+        )
+
+    def test_result_empty_tape(self, device, tol):
+        """Tests that the result has the correct shape and entry types for empty tapes."""
+        dev = device(2)
+
+        empty_tape = qml.tape.QuantumTape()
+        tapes = [empty_tape] * 3
+        res = dev.batch_execute(tapes)
+
+        # We're calling device methods directly, need to reset before the next
+        # execution
+        dev.reset()
+        assert len(res) == 3
+        assert np.allclose(
+            res[0], dev.execute(empty_tape), atol=0
+        )

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -158,7 +158,6 @@ class TestBatchExecution:
             res[0], tape1_expected, atol=0
         )
 
-        dev.reset() # We're calling device methods directly, need to reset
         assert np.allclose(
             res[1], tape2_expected, atol=0
         )


### PR DESCRIPTION
Changes the `QiskitDevice` class to handle the execution of multiple quantum circuits. This addition uses the batch execution pipeline from PennyLane, and the support to run multiple circuit objects from Qiskit.

Related issue: closes #138