### PR TITLE
Add native support for the SX gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Improvements
 
+* Added support for the `qml.SX` operation to the Qiskit devices.
+  [(#158)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/158)
+
 ### Documentation
 
 ### Bug fixes
@@ -13,6 +16,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Antal Száva
 
 ---
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -47,6 +47,7 @@ QISKIT_OPERATION_MAP = {
     "RZ": ex.RZGate,
     "S": ex.SGate,
     "T": ex.TGate,
+    "SX": ex.SXGate,
     # Adding the following for conversion compatibility
     "CSWAP": ex.CSwapGate,
     "CRX": ex.CRXGate,

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -42,7 +42,7 @@ crz = lambda theta: np.array(
 )
 
 
-single_qubit_operations = [qml.PauliX, qml.PauliY, qml.PauliZ, qml.Hadamard, qml.S, qml.T]
+single_qubit_operations = [qml.PauliX, qml.PauliY, qml.PauliZ, qml.Hadamard, qml.S, qml.T, qml.SX]
 
 single_qubit_operations_param = [qml.PhaseShift, qml.RX, qml.RY, qml.RZ]
 two_qubit = [qml.CNOT, qml.SWAP, qml.CZ]

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -476,12 +476,13 @@ class TestConverterGates:
         qc.h(single_wire)
         qc.s(single_wire)
         qc.t(single_wire)
+        qc.sx(single_wire)
 
         quantum_circuit = load(qc)
         with recorder:
             quantum_circuit()
 
-        assert len(recorder.queue) == 6
+        assert len(recorder.queue) == 7
 
         assert recorder.queue[0].name == "PauliX"
         assert recorder.queue[0].parameters == []
@@ -506,6 +507,10 @@ class TestConverterGates:
         assert recorder.queue[5].name == "T"
         assert recorder.queue[5].parameters == []
         assert recorder.queue[5].wires == Wires(single_wire)
+
+        assert recorder.queue[6].name == "SX"
+        assert recorder.queue[6].parameters == []
+        assert recorder.queue[6].wires == Wires(single_wire)
 
     def test_one_qubit_parametrized_operations_supported_by_pennylane(self, recorder):
         """Tests loading a circuit with the one-qubit parametrized operations supported by PennyLane."""

--- a/tests/test_inverses.py
+++ b/tests/test_inverses.py
@@ -22,6 +22,7 @@ class TestInverses:
             ("Hadamard", 0),
             ("S", 1),
             ("T", 1),
+            ("SX", 0)
         ],
     )
     def test_supported_gate_inverse_single_wire_no_parameters(self, name, expected_output):
@@ -250,6 +251,22 @@ class TestInverses:
         def circuit():
             qml.RX(par, wires=[0])
             qml.T(wires=[0]).inv()
+            return qml.expval(qml.PauliX(0))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("par", [np.pi / i for i in range(1, 5)])
+    def test_sx_gate_inverses(self, par):
+        """Tests the inverse of the SX gate"""
+
+        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
+
+        expected_output = math.sin(par)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.RY(par, wires=[0])
+            qml.SX(wires=[0]).inv()
             return qml.expval(qml.PauliX(0))
 
         assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)


### PR DESCRIPTION
Adds an entry to the operation map such that the SX gate is natively supported by the plugin.

Related issue: https://github.com/PennyLaneAI/pennylane/issues/1891, #113