### PR TITLE
Add the `qml.Identity` operation to PennyLane-Qiskit

### DIFF
--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -48,6 +48,7 @@ QISKIT_OPERATION_MAP = {
     "S": ex.SGate,
     "T": ex.TGate,
     "SX": ex.SXGate,
+    "Identity": ex.IGate,
     # Adding the following for conversion compatibility
     "CSWAP": ex.CSwapGate,
     "CRX": ex.CRXGate,

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -42,7 +42,7 @@ crz = lambda theta: np.array(
 )
 
 
-single_qubit_operations = [qml.PauliX, qml.PauliY, qml.PauliZ, qml.Hadamard, qml.S, qml.T, qml.SX]
+single_qubit_operations = [qml.Identity, qml.PauliX, qml.PauliY, qml.PauliZ, qml.Hadamard, qml.S, qml.T, qml.SX]
 
 single_qubit_operations_param = [qml.PhaseShift, qml.RX, qml.RY, qml.RZ]
 two_qubit = [qml.CNOT, qml.SWAP, qml.CZ]


### PR DESCRIPTION
Adds support for the `qml.Identity` operation to the Qiskit plugin, which was previously treated as a `qml.QubitUnitary`.

Support is added for both directions, that is Qiskit backends can handle PennyLane's `Identity` operation, as in this example:
```python
import pennylane as qml
from pennylane_qiskit import BasicAerDevice

dev = BasicAerDevice(1)

@qml.qnode(dev)
def circuit():
    qml.Identity(wires=0)
    return qml.probs(wires=0)

circuit()
```

And the plugin converters correctly translate a Qiskit `IGate` to PennyLane's `Idendity` operation:
```python
import pennylane as qml
from pennylane_qiskit import load
from qiskit import QuantumCircuit

recorder = qml.tape.OperationRecorder()

circ = QuantumCircuit(1)
circ.id(0)

with recorder:
    load(c)()

assert recorder.queue[0].name == "Identity"
```

Closes #153