### PR TITLE
Fix `batch_execute` output type for QNodes with multiple outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### New features since last release
 
+* Defined the `QiskitDevice.batch_execute` method, to allow
+  Qiskit backends to run multiple quantum circuits at the same time. This
+  addition allows submitting batches of circuits to IBMQ e.g., when computing
+  gradients internally.
+  [(#156)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/156)
+  [(#163)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/163)
+
 ### Breaking changes
 
 ### Improvements
@@ -12,7 +19,8 @@
 * Added support for the `qml.SX` operation to the Qiskit devices.
   [(#158)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/158)
 
-* Added support for returning job execution times. [(#160)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/160)
+* Added support for returning job execution times.
+  [(#160)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/160)
 
 ### Documentation
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -409,6 +409,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
                 self._samples = self.generate_samples(circuit_obj)
 
             res = self.statistics(circuit.observables)
+            res = np.asarray(res)
             results.append(res)
 
         if self.tracker.active:

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -155,8 +155,10 @@ class TestBatchExecution:
         tape2_expected = dev.execute(self.tape2)
 
         assert len(res) == 2
+        assert isinstance(res[0], np.ndarray)
         assert np.allclose(res[0], tape1_expected, atol=0)
 
+        assert isinstance(res[1], np.ndarray)
         assert np.allclose(res[1], tape2_expected, atol=0)
 
     def test_result_empty_tape(self, device, tol):


### PR DESCRIPTION
**Context**

[One of the demonstrations fails ](https://github.com/PennyLaneAI/qml/runs/4389087107?check_suite_focus=true#step:8:2416) due to a change of output type when using the `qiskit.aer` device.

With the latest `batch_execute` addition, this device may output results in a different format than other devices (e.g., `default.qubit`).

```python
from pennylane import numpy as np
import pennylane as qml

dev2 = qml.device("qiskit.aer", wires=4)

@qml.qnode(dev2, interface="torch")
def qnode(params):
    qml.RX(params, wires=0)
    return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1)), qml.expval(qml.PauliZ(2))


qnode(0.3)
```
```
[tensor(0.9512, dtype=torch.float64),
 tensor(1., dtype=torch.float64),
 tensor(1., dtype=torch.float64)]
```
whereas it should output
```
tensor([0.9746, 1.0000, 1.0000], dtype=torch.float64)
```
The reason why this causes is an error in the demo is that we're using `torch.stack` in the QNodeCollection class on the results of the underlying QNodes. However, with the latest output type, we may end up having a list in the output, on which `torch.stack` will fail.

Internally, the issue is a missing conversion to `np.array`, that has been done previously when using the default `execute` pipeline.

This can be showcased by comparing the outputs of executing the same tape using the `default.qubit` and the `qiskit.aer` devices:
```python
from pennylane import numpy as np
import pennylane as qml

with qml.tape.QuantumTape() as tape:
    qml.PauliX(wires=0)
    qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliZ(wires=1))

dev1 = qml.device("qiskit.aer", wires=4)
print(dev1.batch_execute([tape]))

dev2 = qml.device("default.qubit", wires=4)

print(dev2.batch_execute([tape]))
```
```
[[-1.0, 1.0]]
[array([-1.,  1.])]
```

**Changes**

Converts the output of `QubitDevice.statistics` to a numpy array to resolve the issue.