### PR TITLE
v0.21.0-dev version bump

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install wheel pytest pytest-cov pytest-mock --upgrade
+          pip install wheel pytest pytest-cov pytest-mock flaky --upgrade
 
       - name: Install Plugin
         run: |

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip install wheel pytest pytest-cov pytest-mock --upgrade
+          pip install wheel pytest pytest-cov pytest-mock flaky --upgrade
 
       - name: Run tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# Release 0.21.0-dev
+
+
+### New features since last release
+
+### Breaking changes
+
+### Improvements
+
+### Documentation
+
+### Bug fixes
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+---
+
 # Release 0.20.0
 
 ### New features since last release

--- a/pennylane_qiskit/_version.py
+++ b/pennylane_qiskit/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.20.0"
+__version__ = "0.21.0-dev"


### PR DESCRIPTION
The Qiskit upload failed because Flaky is not installed in the deploy action. As a result, the auto version bump PR did not occur.

Closes #171.