### PR TITLE
Fix plugin matrix tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Features
 Installation
 ============
 
-This plugin requires Python version 3.5 and above, as well as PennyLane and Qiskit.
+This plugin requires Python version 3.7 and above, as well as PennyLane and Qiskit.
 Installation of this plugin, as well as all dependencies, can be done using ``pip``:
 
 .. code-block:: bash

--- a/tests/test_ibmq.py
+++ b/tests/test_ibmq.py
@@ -32,6 +32,7 @@ def test_load_from_env(token, monkeypatch):
     dev = IBMQDevice(wires=1)
     assert dev.provider.credentials.is_ibmq()
 
+
 def test_load_from_env_multiple_device(token, monkeypatch):
     """Test creating multiple IBMQ devices when the environment variable
     for the IBMQ token was set."""
@@ -41,6 +42,7 @@ def test_load_from_env_multiple_device(token, monkeypatch):
 
     assert dev1.provider.credentials.is_ibmq()
     assert dev2.provider.credentials.is_ibmq()
+
 
 def test_load_from_env_multiple_device_and_token(monkeypatch):
     """Test creating multiple devices when the different tokens are defined
@@ -52,11 +54,14 @@ def test_load_from_env_multiple_device_and_token(monkeypatch):
         m.setattr(ibmq.QiskitDevice, "__init__", mock_qiskit_device.mocked_init)
 
         creds = []
+
         def enable_account(new_creds):
             creds.append(new_creds)
+
         def active_account():
             if len(creds) != 0:
-                return { "token": creds[-1] }
+                return {"token": creds[-1]}
+
         m.setattr(ibmq.IBMQ, "enable_account", enable_account)
         m.setattr(ibmq.IBMQ, "disable_account", lambda: None)
         m.setattr(ibmq.IBMQ, "active_account", active_account)
@@ -73,6 +78,7 @@ def test_load_from_env_multiple_device_and_token(monkeypatch):
         dev2 = IBMQDevice(wires=1, provider=mock_provider)
         # second login
         assert creds == ["TOKEN1", "TOKEN2"]
+
 
 def test_load_kwargs_takes_precedence(token, monkeypatch):
     """Test that with a potentially valid token stored as an environment
@@ -111,7 +117,7 @@ def test_custom_provider(monkeypatch):
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
 
         # Here mocking to a value such that it is not None
-        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {})
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {token: '1'})
         dev = IBMQDevice(wires=2, backend="ibmq_qasm_simulator", provider=mock_provider)
 
     assert mock_qiskit_device.provider == mock_provider
@@ -134,7 +140,7 @@ def test_default_provider(monkeypatch):
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
 
         # Here mocking to a value such that it is not None
-        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {})
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {token: '1'})
         dev = IBMQDevice(wires=2, backend="ibmq_qasm_simulator")
 
     assert mock_qiskit_device.provider[0] == ()
@@ -156,7 +162,7 @@ def test_custom_provider_hub_group_project(monkeypatch):
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
 
         # Here mocking to a value such that it is not None
-        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {})
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {token: '1'})
         dev = IBMQDevice(
             wires=2,
             backend="ibmq_qasm_simulator",

--- a/tests/test_ibmq.py
+++ b/tests/test_ibmq.py
@@ -117,7 +117,7 @@ def test_custom_provider(monkeypatch):
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
 
         # Here mocking to a value such that it is not None
-        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {token: '1'})
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {"token": '1'})
         dev = IBMQDevice(wires=2, backend="ibmq_qasm_simulator", provider=mock_provider)
 
     assert mock_qiskit_device.provider == mock_provider
@@ -140,7 +140,7 @@ def test_default_provider(monkeypatch):
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
 
         # Here mocking to a value such that it is not None
-        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {token: '1'})
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {"token": '1'})
         dev = IBMQDevice(wires=2, backend="ibmq_qasm_simulator")
 
     assert mock_qiskit_device.provider[0] == ()
@@ -162,7 +162,7 @@ def test_custom_provider_hub_group_project(monkeypatch):
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
 
         # Here mocking to a value such that it is not None
-        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {token: '1'})
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {"token": '1'})
         dev = IBMQDevice(
             wires=2,
             backend="ibmq_qasm_simulator",


### PR DESCRIPTION
The CI checks do not fail but the plugin matrix is. It is probably due to how the IBMQ token is set in the environment.