### PR TITLE
Fix bugs for the trainable arguments update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Features
 Installation
 ============
 
-This plugin requires Python version 3.5 and above, as well as PennyLane and Qiskit.
+This plugin requires Python version 3.7 and above, as well as PennyLane and Qiskit.
 Installation of this plugin, as well as all dependencies, can be done using ``pip``:
 
 .. code-block:: bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 qiskit>=0.25
-pennylane>=0.20
+git+https://github.com/PennyLaneAI/pennylane
 numpy
 sympy
 networkx>=2.2;python_version>'3.5'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.rst", "r") as fh:
 
 requirements = [
     "qiskit>=0.25",
-    "pennylane>=0.20",
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git",
     "numpy",
     "networkx>=2.2",
 ]

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1115,8 +1115,8 @@ class TestConverterIntegration:
         jac = qml.jacobian(circuit)(x, y)
 
         jac_expected = [
-            [-np.sin(x + np.cos(y)), np.sin(x + np.cos(y)) * np.sin(y)],
-            [np.cos(x * y) * y, np.cos(x * y) * x],
+            [-np.sin(x + np.cos(y)), np.cos(x * y) * y],
+            [np.sin(x + np.cos(y)) * np.sin(y), np.cos(x * y) * x],
         ]
 
         assert np.allclose(jac, jac_expected)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1115,8 +1115,8 @@ class TestConverterIntegration:
         jac = qml.jacobian(circuit)(x, y)
 
         jac_expected = [
-            [-np.sin(x + np.cos(y)), np.cos(x * y) * y],
-            [np.sin(x + np.cos(y)) * np.sin(y), np.cos(x * y) * x],
+            [-np.sin(x + np.cos(y)), np.sin(x + np.cos(y)) * np.sin(y)],
+            [np.cos(x * y) * y, np.cos(x * y) * x],
         ]
 
         assert np.allclose(jac, jac_expected)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1104,8 +1104,8 @@ class TestConverterIntegration:
             load(qc)({a: a_val, b: b_val}, wires=(0, 1))
             return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliX(1))
 
-        x = 0.1
-        y = 0.2
+        x = np.array(0.1, requires_grad=True)
+        y = np.array(0.2, requires_grad=True)
 
         res = circuit(x, y)
         res_expected = [np.cos(x + np.cos(y)), np.sin(x * y)]
@@ -1115,8 +1115,8 @@ class TestConverterIntegration:
         jac = qml.jacobian(circuit)(x, y)
 
         jac_expected = [
-            [-np.sin(x + np.cos(y)), np.sin(x + np.cos(y)) * np.sin(y)],
-            [np.cos(x * y) * y, np.cos(x * y) * x],
+            [-np.sin(x + np.cos(y)), np.cos(x * y) * y],
+            [np.sin(x + np.cos(y)) * np.sin(y), np.cos(x * y) * x],
         ]
 
         assert np.allclose(jac, jac_expected)

--- a/tests/test_ibmq.py
+++ b/tests/test_ibmq.py
@@ -32,6 +32,7 @@ def test_load_from_env(token, monkeypatch):
     dev = IBMQDevice(wires=1)
     assert dev.provider.credentials.is_ibmq()
 
+
 def test_load_from_env_multiple_device(token, monkeypatch):
     """Test creating multiple IBMQ devices when the environment variable
     for the IBMQ token was set."""
@@ -41,6 +42,7 @@ def test_load_from_env_multiple_device(token, monkeypatch):
 
     assert dev1.provider.credentials.is_ibmq()
     assert dev2.provider.credentials.is_ibmq()
+
 
 def test_load_from_env_multiple_device_and_token(monkeypatch):
     """Test creating multiple devices when the different tokens are defined
@@ -52,11 +54,14 @@ def test_load_from_env_multiple_device_and_token(monkeypatch):
         m.setattr(ibmq.QiskitDevice, "__init__", mock_qiskit_device.mocked_init)
 
         creds = []
+
         def enable_account(new_creds):
             creds.append(new_creds)
+
         def active_account():
             if len(creds) != 0:
-                return { "token": creds[-1] }
+                return {"token": creds[-1]}
+
         m.setattr(ibmq.IBMQ, "enable_account", enable_account)
         m.setattr(ibmq.IBMQ, "disable_account", lambda: None)
         m.setattr(ibmq.IBMQ, "active_account", active_account)
@@ -73,6 +78,7 @@ def test_load_from_env_multiple_device_and_token(monkeypatch):
         dev2 = IBMQDevice(wires=1, provider=mock_provider)
         # second login
         assert creds == ["TOKEN1", "TOKEN2"]
+
 
 def test_load_kwargs_takes_precedence(token, monkeypatch):
     """Test that with a potentially valid token stored as an environment
@@ -219,7 +225,7 @@ def test_simple_circuit_with_batch_params(token, tol, shots, mocker):
     IBMQ.enable_account(token)
     dev = IBMQDevice(wires=2, backend="ibmq_qasm_simulator", shots=shots)
 
-    @qml.batch_params
+    @qml.batch_params(all_operations=True)
     @qml.qnode(dev)
     def circuit(theta, phi):
         qml.RX(theta, wires=0)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -516,7 +516,7 @@ class TestBatchExecution:
         spy1 = mocker.spy(QiskitDevice, "batch_execute")
         spy2 = mocker.spy(dev.backend, "run")
 
-        @qml.batch_params
+        @qml.batch_params(all_operations=True)
         @qml.qnode(dev)
         def circuit(x, y, z):
             """Reference QNode"""


### PR DESCRIPTION
A recent PR changed the behavior of arguments, their trainability and the batch_params transform. We updated the arguments for one test and the @batch_params argument for another test.