### PR TITLE
V0.22 dev bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Release 0.21.1
+# Release 0.22.0-dev
+
+### New features since last release
+
+### Breaking changes
 
 ### Improvements
 
@@ -8,6 +12,10 @@
   
 * Changed the VQE callback function for SciPy optimizers.
   [(#187)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/187)
+
+### Documentation
+
+### Bug fixes
 
 ### Contributors
 

--- a/pennylane_qiskit/_version.py
+++ b/pennylane_qiskit/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.21.1"
+__version__ = "0.22.0-dev"


### PR DESCRIPTION
Restores the 0.22.0-dev version details. No v0.21.1 release was made as the issue on the Qiskit side were fixed.