### PR TITLE
Rename token environment variable

### DIFF
--- a/.github/workflows/ibmq_tests.yml
+++ b/.github/workflows/ibmq_tests.yml
@@ -40,4 +40,4 @@ jobs:
         # Only run IBMQ and Runtime tests (skipped otherwise)
         run: python -m pytest tests -k 'test_ibmq.py or test_runtime.py' --cov=pennylane_qiskit --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
         env:
-          IBMQX_TOKEN_TEST: ${{ secrets.IBMQX_TOKEN_TEST }}
+          IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN_TEST }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         # easily result in timeouts
         run: python -m pytest tests -k 'not test_ibmq.py and not test_runtime.py' --cov=pennylane_qiskit --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
         env:
-          IBMQX_TOKEN_TEST: ${{ secrets.IBMQX_TOKEN_TEST }}
+          IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN_TEST }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ hw_backends = ["qasm_simulator", "aer_simulator"]
 
 @pytest.fixture
 def token():
-    t = os.getenv("IBMQX_TOKEN_TEST", None)
+    t = os.getenv("IBMQX_TOKEN", None)
 
     if t is None:
         pytest.skip("Skipping test, no IBMQ token available")


### PR DESCRIPTION
Rename `IBMQX_TOKEN_TEST` to `IBMQX_TOKEN` for more coherence.