### PR TITLE
Pin to PennyLane `>=v0.22`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 qiskit>=0.32
 mthree>=0.17.2
-git+https://github.com/PennyLaneAI/pennylane.git
+pennylane>=0.22
 qiskit>=0.25
 numpy
 sympy

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.rst", "r") as fh:
 requirements = [
     "qiskit>=0.25",
     "mthree>=0.17",
-    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git",
+    "pennylane>=0.22",
     "numpy",
     "networkx>=2.2",
 ]


### PR DESCRIPTION
Some of the PennyLane API used in the plugin depends on changes available from PennyLane v0.22.0 (https://github.com/PennyLaneAI/pennylane-qiskit/pull/190). Therefore, the required version of PennyLane is being increased.

*Note:* the checks in this PR will be failing until v0.22.0 of PennyLane has been released.