### PR TITLE
Update runtime sampler

### DIFF
--- a/pennylane_qiskit/runtime_devices.py
+++ b/pennylane_qiskit/runtime_devices.py
@@ -169,7 +169,7 @@ class IBMQSamplerDevice(IBMQDevice):
             program_id="sampler", options=options, inputs=program_inputs
         )
         self._current_job = job.result()
-        print(self._current_job)
+
         results = []
 
         counter = 0
@@ -200,9 +200,9 @@ class IBMQSamplerDevice(IBMQDevice):
              array[complex]: array of samples in the shape ``(dev.shots, dev.num_wires)``
         """
         counts = self._current_job.get("quasi_dists")[circuit_id]
-        number_of_states = 2 ** self.num_wires
-
         keys = list(counts.keys())
+
+        number_of_states = 2 ** len(keys[0])
 
         # Convert state to int
         for i, elem in enumerate(keys):
@@ -221,4 +221,6 @@ class IBMQSamplerDevice(IBMQDevice):
                     states.insert(i, i)
                     probs.insert(i, 0.0)
 
-        return self.states_to_binary(self.sample_basis_states(number_of_states, probs), self.num_wires)
+        return self.states_to_binary(
+            self.sample_basis_states(number_of_states, probs), self.num_wires
+        )

--- a/pennylane_qiskit/runtime_devices.py
+++ b/pennylane_qiskit/runtime_devices.py
@@ -150,7 +150,7 @@ class IBMQSamplerDevice(IBMQDevice):
 
         if "circuits_indices" not in self.kwargs:
             circuit_indices = list(range(0, len(compiled_circuits)))
-            program_inputs["circuits_indices"] = circuit_indices
+            program_inputs["circuit_indices"] = circuit_indices
         else:
             circuit_indices = self.kwargs.get("circuit_indices")
 

--- a/pennylane_qiskit/runtime_devices.py
+++ b/pennylane_qiskit/runtime_devices.py
@@ -18,7 +18,6 @@ This module contains classes for constructing Qiskit runtime devices for PennyLa
 
 import numpy as np
 
-import qiskit.result.postprocess
 from qiskit.providers.ibmq import RunnerResult
 from pennylane_qiskit.ibmq import IBMQDevice
 

--- a/pennylane_qiskit/runtime_devices.py
+++ b/pennylane_qiskit/runtime_devices.py
@@ -149,7 +149,7 @@ class IBMQSamplerDevice(IBMQDevice):
         program_inputs = {"circuits": compiled_circuits}
 
         if "circuits_indices" not in self.kwargs:
-            circuit_indices = range(0, len(compiled_circuits))
+            circuit_indices = list(range(0, len(compiled_circuits)))
             program_inputs["circuits_indices"] = circuit_indices
         else:
             circuit_indices = self.kwargs.get("circuit_indices")

--- a/tests/test_ibmq.py
+++ b/tests/test_ibmq.py
@@ -111,10 +111,12 @@ def test_custom_provider(monkeypatch):
     device."""
     mock_provider = "MockProvider"
     mock_qiskit_device = MockQiskitDeviceInit()
+    monkeypatch.setenv("IBMQX_TOKEN", '1')
 
     with monkeypatch.context() as m:
         m.setattr(ibmq.QiskitDevice, "__init__", mock_qiskit_device.mocked_init)
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
+
 
         # Here mocking to a value such that it is not None
         m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {"token": '1'})
@@ -133,6 +135,7 @@ def test_default_provider(monkeypatch):
     """Tests that the default provider is used when no custom provider was
     specified."""
     mock_qiskit_device = MockQiskitDeviceInit()
+    monkeypatch.setenv("IBMQX_TOKEN", '1')
 
     with monkeypatch.context() as m:
         m.setattr(ibmq.QiskitDevice, "__init__", mock_qiskit_device.mocked_init)
@@ -151,6 +154,7 @@ def test_custom_provider_hub_group_project(monkeypatch):
     """Tests that the custom arguments passed during device instantiation are
     used when calling get_provider."""
     mock_qiskit_device = MockQiskitDeviceInit()
+    monkeypatch.setenv("IBMQX_TOKEN", '1')
 
     custom_hub = "SomeHub"
     custom_group = "SomeGroup"

--- a/tests/test_ibmq.py
+++ b/tests/test_ibmq.py
@@ -117,7 +117,7 @@ def test_custom_provider(monkeypatch):
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
 
         # Here mocking to a value such that it is not None
-        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {})
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {"token": '1'})
         dev = IBMQDevice(wires=2, backend="ibmq_qasm_simulator", provider=mock_provider)
 
     assert mock_qiskit_device.provider == mock_provider
@@ -140,7 +140,7 @@ def test_default_provider(monkeypatch):
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
 
         # Here mocking to a value such that it is not None
-        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {})
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {"token": '1'})
         dev = IBMQDevice(wires=2, backend="ibmq_qasm_simulator")
 
     assert mock_qiskit_device.provider[0] == ()
@@ -162,7 +162,7 @@ def test_custom_provider_hub_group_project(monkeypatch):
         m.setattr(ibmq.IBMQ, "enable_account", lambda *args, **kwargs: None)
 
         # Here mocking to a value such that it is not None
-        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {})
+        m.setattr(ibmq.IBMQ, "active_account", lambda *args, **kwargs: {"token": '1'})
         dev = IBMQDevice(
             wires=2,
             backend="ibmq_qasm_simulator",

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -177,11 +177,9 @@ class TestSampler:
         "kwargs",
         [
             {
-                "return_mitigation_overhead": True,
+                "circuit_indices": [0],
                 "run_config": {"seed_simulator": 42},
                 "skip_transpilation": False,
-                "transpile_config": {"approximation_degree": 1.0},
-                "use_measurement_mitigation": True,
             }
         ],
     )

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -23,10 +23,17 @@ from qiskit import IBMQ
 
 from pennylane_qiskit import opstr_to_meas_circ
 from pennylane_qiskit import IBMQCircuitRunnerDevice, IBMQSamplerDevice
-from pennylane_qiskit.vqe_runtime_runner import vqe_runner, upload_vqe_runner, delete_vqe_runner, hamiltonian_to_list_string
+from pennylane_qiskit.vqe_runtime_runner import (
+    vqe_runner,
+    upload_vqe_runner,
+    delete_vqe_runner,
+    hamiltonian_to_list_string,
+)
+
 
 class TestCircuitRunner:
     """Test class for the circuit runner IBMQ runtime device."""
+
     def test_load_from_env(self, token, monkeypatch):
         """Test loading an IBMQ Circuit Runner Qiskit runtime device from an env variable."""
         monkeypatch.setenv("IBMQX_TOKEN", token)
@@ -141,6 +148,7 @@ class TestCircuitRunner:
 
 class TestSampler:
     """Test class for the sampler IBMQ runtime device."""
+
     def test_load_from_env(self, token, monkeypatch):
         """Test loading an IBMQ Sampler Qiskit runtime device from an env variable."""
         monkeypatch.setenv("IBMQX_TOKEN", token)
@@ -206,7 +214,7 @@ class TestSampler:
     def test_batch_circuits(self, token, tol, shots):
         """Test executing batched circuits submitted to IBMQ using the Sampler device."""
         IBMQ.enable_account(token)
-        dev = IBMQSamplerDevice(wires=2, backend="ibmq_qasm_simulator", shots=shots)
+        dev = IBMQSamplerDevice(wires=1, backend="ibmq_qasm_simulator", shots=shots)
 
         # Batch the input parameters
         batch_dim = 3
@@ -253,19 +261,25 @@ class TestCustomVQE:
         hamiltonian = qml.Hamiltonian(coeffs, obs)
         result = hamiltonian_to_list_string(hamiltonian, hamiltonian.wires)
 
-        assert [(1, 'XIX'), (1, 'HZI')] == result
+        assert [(1, "XIX"), (1, "HZI")] == result
 
     def test_op_str_measurement_circ(self):
         """Test that the opstr_to_meas_circ function finds the necessary rotations before measurements in the
-        circuit. """
-        circ = opstr_to_meas_circ('HIHXZ')
+        circuit."""
+        circ = opstr_to_meas_circ("HIHXZ")
         results = []
         for c in circ:
             if c:
                 results.append((c.data[0][0].name, c.data[0][0].params))
             else:
                 results.append(())
-        assert [('ry', [-0.7853981633974483]), (), ('ry', [-0.7853981633974483]), ('h', []), ()] == results
+        assert [
+            ("ry", [-0.7853981633974483]),
+            (),
+            ("ry", [-0.7853981633974483]),
+            ("h", []),
+            (),
+        ] == results
 
     @pytest.mark.parametrize("shots", [8000])
     def test_simple_hamiltonian(self, token, tol, shots):
@@ -348,7 +362,9 @@ class TestCustomVQE:
         hamiltonian = qml.Hamiltonian(coeffs, obs)
         program_id = upload_vqe_runner(hub="ibm-q-startup", group="xanadu", project="reservations")
 
-        with pytest.raises(ValueError, match="Ansatz InEfficientSU2 not in n_local circuit library."):
+        with pytest.raises(
+            ValueError, match="Ansatz InEfficientSU2 not in n_local circuit library."
+        ):
             vqe_runner(
                 program_id=program_id,
                 backend="ibmq_qasm_simulator",
@@ -356,7 +372,11 @@ class TestCustomVQE:
                 ansatz="InEfficientSU2",
                 x0=[3.97507603, 3.00854038],
                 shots=shots,
-                kwargs={"hub": "ibm-q-startup", "group": "ibm-q-startup", "project": "reservations"},
+                kwargs={
+                    "hub": "ibm-q-startup",
+                    "group": "ibm-q-startup",
+                    "project": "reservations",
+                },
             )
 
         provider = IBMQ.get_provider(hub="ibm-q-startup", group="xanadu", project="reservations")
@@ -377,7 +397,9 @@ class TestCustomVQE:
         hamiltonian = qml.Hamiltonian(coeffs, obs)
         program_id = upload_vqe_runner(hub="ibm-q-startup", group="xanadu", project="reservations")
 
-        with pytest.raises(qml.QuantumFunctionError, match="The ansatz must be a callable quantum function."):
+        with pytest.raises(
+            qml.QuantumFunctionError, match="The ansatz must be a callable quantum function."
+        ):
             vqe_runner(
                 program_id=program_id,
                 backend="ibmq_qasm_simulator",
@@ -415,7 +437,9 @@ class TestCustomVQE:
         hamiltonian = qml.Hamiltonian(coeffs, obs)
         program_id = upload_vqe_runner(hub="ibm-q-startup", group="xanadu", project="reservations")
 
-        with pytest.raises(qml.QuantumFunctionError, match="The ansatz must be a callable quantum function."):
+        with pytest.raises(
+            qml.QuantumFunctionError, match="The ansatz must be a callable quantum function."
+        ):
             vqe_runner(
                 program_id=program_id,
                 backend="ibmq_qasm_simulator",
@@ -565,12 +589,16 @@ class TestCustomVQE:
                 x0=[3.97507603, 3.00854038, 3.55637849],
                 shots=shots,
                 optimizer_config={"maxiter": 10},
-                kwargs={"hub": "ibm-q-startup", "group": "ibm-q-startup", "project": "reservations"},
+                kwargs={
+                    "hub": "ibm-q-startup",
+                    "group": "ibm-q-startup",
+                    "project": "reservations",
+                },
             )
 
         assert (
-                record[-1].message.args[0]
-                == "In order to match the tape expansion, the number of parameters has been changed."
+            record[-1].message.args[0]
+            == "In order to match the tape expansion, the number of parameters has been changed."
         )
 
         provider = IBMQ.get_provider(hub="ibm-q-startup", group="xanadu", project="reservations")
@@ -704,7 +732,9 @@ class TestCustomVQE:
         hamiltonian = qml.PauliZ(wires=0)
         program_id = upload_vqe_runner(hub="ibm-q-startup", group="xanadu", project="reservations")
 
-        with pytest.raises(qml.QuantumFunctionError, match="A PennyLane Hamiltonian object is required."):
+        with pytest.raises(
+            qml.QuantumFunctionError, match="A PennyLane Hamiltonian object is required."
+        ):
             vqe_runner(
                 program_id=program_id,
                 backend="ibmq_qasm_simulator",
@@ -919,7 +949,9 @@ class TestCustomVQE:
         hamiltonian = qml.Hamiltonian(coeffs, obs)
         program_id = upload_vqe_runner(hub="ibm-q-startup", group="xanadu", project="reservations")
 
-        with pytest.raises(qml.QuantumFunctionError, match="Function contains no quantum operations."):
+        with pytest.raises(
+            qml.QuantumFunctionError, match="Function contains no quantum operations."
+        ):
             vqe_runner(
                 program_id=program_id,
                 backend="ibmq_qasm_simulator",
@@ -937,7 +969,6 @@ class TestCustomVQE:
 
         provider = IBMQ.get_provider(hub="ibm-q-startup", group="xanadu", project="reservations")
         delete_vqe_runner(provider=provider, program_id=program_id)
-
 
     @pytest.mark.parametrize("shots", [8000])
     def test_invalid_ansatz(self, token, tol, shots):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -178,7 +178,7 @@ class TestSampler:
         [
             {
                 "circuit_indices": [0],
-                "run_config": {"seed_simulator": 42},
+                "run_options": {"seed_simulator": 42},
                 "skip_transpilation": False,
             }
         ],


### PR DESCRIPTION
The runtime `sampler` was updated on March 17 by IBM, some changes in the arguments of the runtime program are needed. The results are returned as probabilities instead of counts, therefore the `generate_samples` function is adapted.