### PR TITLE
Pin qiskit to `>=0.32` for use of runtime programs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 qiskit>=0.32
 mthree>=0.17.2
 pennylane>=0.22
-qiskit>=0.25
 numpy
 sympy
 networkx>=2.2;python_version>'3.5'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 requirements = [
-    "qiskit>=0.25",
+    "qiskit>=0.32",
     "mthree>=0.17",
     "pennylane>=0.22",
     "numpy",


### PR DESCRIPTION
Pin Qiskit to version `>=0.32` for use of runtime programs.