### PR TITLE
Define `returns_state` in `capabilities`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@
 
 This release contains contributions from (in alphabetical order):
 
-Mikhail Andrenkov, Christina Lee, Romain Moyard
+Mikhail Andrenkov, Christina Lee, Romain Moyard, Antal Száva
+
 ---
 # Release 0.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Improvements
 
 * Improvement of the different `requirements.txt` and `requirements-ci.txt` files.
-[(#212)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/212)
+  [(#212)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/212)
 
 * The plugin now natively supports the adjoint of the `S`, `T`, and `SX` gates.
   [(#216)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/216)
@@ -16,9 +16,13 @@
 
 * Use the centralized [Xanadu Sphinx Theme](https://github.com/XanaduAI/xanadu-sphinx-theme)
   to style the Sphinx documentation.
-[(#215)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/215)
+  [(#215)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/215)
 
 ### Bug fixes
+
+* Defines the missing `returns_state` entry of the
+  `capabilities` dictionary for devices.
+  [(#220)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/220)
 
 ### Contributors
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -146,6 +146,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         self.provider = provider
         self.backend_name = backend
         self._capabilities["backend"] = [b.name() for b in self.provider.backends()]
+        self._capabilities["returns_state"] = backend in self._state_backends
 
         # Check that the backend exists
         if backend not in self._capabilities["backend"]:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -31,6 +31,7 @@ class TestDeviceIntegration:
         assert dev.shots == 1024
         assert dev.short_name == d[0]
         assert dev.provider == d[1]
+        assert dev.capabilities()["returns_state"] == (backend in state_backends)
 
     def test_incorrect_backend(self):
         """Test that exception is raised if name is incorrect"""


### PR DESCRIPTION
The state backend devices are capable of returning the state, yet they don't have the `returns_state=True` entry in the `capabilities` dictionary of the device (see [the explanation of `capabilities` here](https://pennylane.readthedocs.io/en/stable/development/plugins.html#device-capabilities)).