### PR TITLE
Update `semantic_version` to 2.10

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
-pennylane
+git+https://github.com/PennyLaneAI/pennylane.git
 qiskit
 mthree
 numpy

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
-git+https://github.com/PennyLaneAI/pennylane.git
+pennylane
 qiskit
 mthree
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ requests==2.27.1
 requests-ntlm==1.1.0
 retworkx==0.11.0
 scipy==1.8.0
-semantic-version==2.6.0
+semantic-version==2.10.0
 six==1.16.0
 stevedore==3.5.0
 symengine==0.9.2


### PR DESCRIPTION
PennyLane will be updated to use the new semantic-version API requiring a version number >=2.7

See PennyLaneAI/pennylane#2744

[To be updated after the next PL release]