### PR TITLE
add support for iswap gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### New features since last release
 
+* Add support for the `ISWAP` operation.
+  [(#229)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/229)
+
 ### Breaking changes
 
 ### Improvements
@@ -13,6 +16,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Matthew Silverman
 
 ---
 # Release 0.24.0

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -41,6 +41,7 @@ QISKIT_OPERATION_MAP = {
     "CNOT": ex.CXGate,
     "CZ": ex.CZGate,
     "SWAP": ex.SwapGate,
+    "ISWAP": ex.iSwapGate,
     "RX": ex.RXGate,
     "RY": ex.RYGate,
     "RZ": ex.RZGate,

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -73,7 +73,7 @@ single_qubit_operations = [qml.Identity, qml.PauliX, qml.PauliY, qml.PauliZ, qml
     qml.adjoint(qml.T), qml.adjoint(qml.S), qml.adjoint(qml.SX)]
 
 single_qubit_operations_param = [qml.PhaseShift, qml.RX, qml.RY, qml.RZ]
-two_qubit = [qml.CNOT, qml.SWAP, qml.CZ]
+two_qubit = [qml.CNOT, qml.SWAP, qml.CZ, qml.ISWAP]
 two_qubit_param = [qml.CRZ, qml.IsingXX, qml.IsingYY, qml.IsingZZ]
 three_qubit = [qml.Toffoli, qml.CSWAP]
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -590,13 +590,10 @@ class TestConverterGates:
 
         qc = QuantumCircuit(2, 1)
 
-        unitary_op = [[1, 0, 0, 0], [0, 0, 1j, 0], [0, 1j, 0, 0], [0, 0, 0, 1]]
-        iswap_op = Operator(unitary_op)
-
         qc.cx(*two_wires)
         qc.cz(*two_wires)
         qc.swap(*two_wires)
-        qc.unitary(iswap_op, [0, 1], label="iswap")
+        qc.iswap(*two_wires)
 
         quantum_circuit = load(qc)
         with recorder:
@@ -616,9 +613,8 @@ class TestConverterGates:
         assert recorder.queue[2].parameters == []
         assert recorder.queue[2].wires == Wires(two_wires)
 
-        assert recorder.queue[3].name == "QubitUnitary"
-        assert len(recorder.queue[3].parameters) == 1
-        assert np.array_equal(recorder.queue[3].parameters[0], np.array(unitary_op))
+        assert recorder.queue[3].name == "ISWAP"
+        assert recorder.queue[3].parameters == []
         assert recorder.queue[3].wires == Wires(two_wires)
 
     def test_two_qubit_parametrized_operations_supported_by_pennylane(self, recorder):


### PR DESCRIPTION
the ISWAP gate exists in both Qiskit and PennyLane, so this PR adds support for it.