### PR TITLE
Fix Cobyla success bool for VQE runtime

### DIFF
--- a/pennylane_qiskit/vqe_runtime_program.py
+++ b/pennylane_qiskit/vqe_runtime_program.py
@@ -182,5 +182,6 @@ def main(
         res = opt.minimize(
             vqe_func, x0, method=optimizer, options=optimizer_config, callback=callback
         )
+        res.success = bool(res)
 
     return res

--- a/pennylane_qiskit/vqe_runtime_program.py
+++ b/pennylane_qiskit/vqe_runtime_program.py
@@ -182,6 +182,6 @@ def main(
         res = opt.minimize(
             vqe_func, x0, method=optimizer, options=optimizer_config, callback=callback
         )
-        res.success = bool(res)
+        res.success = bool(res.success)
 
     return res


### PR DESCRIPTION
Success attribute is a numpy bool for the COBYLA optimizer and is not JSON serializable. The solution is to cast it to `bool`

Related issue: https://github.com/PennyLaneAI/pennylane/issues/3130