### PR TITLE
Add sphinx version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,6 +3,8 @@ docutils==0.16
 ipykernel==6.13.0
 jinja2==3.0.3
 mthree==0.22.0
+sphinx==3.5; python_version < "3.10"
+sphinx==4.2; python_version == "3.10"
 nbsphinx==0.8.8
 git+https://github.com/XanaduAI/pennylane.git#egg=pennylane
 pybind11==2.9.2


### PR DESCRIPTION
In `.github/workflows/docs.yml` we are using the action: `PennyLaneAI/sphinx-action@master` ([see repo](https://github.com/PennyLaneAI/sphinx-action)), which requires sphinx version `2.2.0`. Should we update this version instead?