### PR TITLE
bump pl requires version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * `.inv` is replaced by `qml.adjoint` in PennyLane `0.30.0` and therefore the plugin is adapted as well.
   [(#260)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/260)
 
+* The minimum required version of PennyLane is bumped to `0.28`. The current plugin
+  does not work with PennyLane v0.27.
+
 ### Bug fixes
 
 * The number of executions of the device is now correct.
@@ -14,6 +17,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Christina Lee
 Romain Moyard
 
 ---

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -104,7 +104,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
             to simulate a device compliant circuit, you can specify a backend here.
     """
     name = "Qiskit PennyLane plugin"
-    pennylane_requires = ">=0.20.0"
+    pennylane_requires = ">=0.28.0"
     version = __version__
     plugin_version = __version__
     author = "Xanadu"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.rst", "r") as fh:
 requirements = [
     "qiskit>=0.32",
     "mthree>=0.17",
-    "pennylane>=0.23",
+    "pennylane>=0.28",
     "numpy",
     "networkx>=2.2",
 ]


### PR DESCRIPTION
While the test suite passes with PL v0.28 and the v0.29 release candidate, the test suite fails with PL v0.27.

For example, I am getting failures may look like:
```
FAILED pennylane/devices/tests/test_gates.py::TestSupportedGates::test_supported_gates_can_be_implemented[device_kwargs0-CNOT] - AttributeError: 'CNOT' object has no attribute 'return_type'
```

Therefore I'm bumping the PL requirement to be at least v0.28.