### PR TITLE
Put back master requirement; fix batching

### DIFF
--- a/pennylane_qiskit/runtime_devices.py
+++ b/pennylane_qiskit/runtime_devices.py
@@ -78,6 +78,8 @@ class IBMQCircuitRunnerDevice(IBMQDevice):
         for index, circuit in enumerate(circuits):
             self._samples = self.generate_samples(index)
             res = self.statistics(circuit)
+            single_measurement = len(circuit.measurements) == 1
+            res = res[0] if single_measurement else tuple(res)
             results.append(res)
 
         if self.tracker.active:
@@ -175,6 +177,8 @@ class IBMQSamplerDevice(IBMQDevice):
                 self._samples = self.generate_samples(counter)
                 counter += 1
                 res = self.statistics(circuit)
+                single_measurement = len(circuit.measurements) == 1
+                res = res[0] if single_measurement else tuple(res)
                 results.append(res)
 
         if self.tracker.active:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.rst", "r") as fh:
 requirements = [
     "qiskit>=0.32",
     "mthree>=0.17",
-    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@v0.30.0-rc0",
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git",
     "numpy",
     "networkx>=2.2",
 ]


### PR DESCRIPTION
as title says. pinning this breaks qml, and batching didn't work with new return systems on the runtime devices