### PR TITLE
Add qiskit.generic device that accepts instantiated qiskit backends.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### New features since last release
 
+* Added a `GenericDevice` (PennyLane device name: `qiskit.generic`) that accepts a backend
+  instance directly. [(#304)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/304)
+
 ### Breaking changes
 
 ### Improvements
@@ -13,6 +16,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Etienne Wodey (Alpine Quantum Technologies GmbH)
 
 ---
 # Release 0.30.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features since last release
 
-* Added a `GenericDevice` (PennyLane device name: `qiskit.generic`) that accepts a backend
+* Added a `RemoteDevice` (PennyLane device name: `qiskit.remote`) that accepts a backend
   instance directly. [(#304)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/304)
 
 ### Breaking changes

--- a/doc/devices/remote.rst
+++ b/doc/devices/remote.rst
@@ -1,0 +1,20 @@
+The Remote device
+===================
+
+The ``'qiskit.remote'`` device is a generic adapter to use any Qiskit backend as interface
+for a PennyLane device.
+
+This device is useful when retrieving backends from providers with complex search options in
+their ``get_backend()`` method, or for setting options on a backend prior to wrapping it as
+PennyLane device.
+
+.. code-block:: python
+
+    import pennylane as qml
+
+    def configured_backend():
+        backend = SomeProvider.get_backend(...)
+	backend.options.update_options(...)
+	return backend
+
+    dev = qml.device('qiskit.remote', wires=2, backend=configured_backend())

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -41,6 +41,11 @@ Currently, there are three different devices available:
     :description: Allows integration with qiskit's sampler runtime program.
     :link: devices/runtime.html
 
+.. title-card::
+    :name: 'qiskit.remote'
+    :description: Allows integration with any qiskit backend.
+    :link: devices/remote.html
+
 .. raw:: html
 
     <div style='clear:both'></div>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -129,6 +129,7 @@ hardware access.
    devices/basicaer
    devices/ibmq
    devices/runtime
+   devices/remote
 
 .. toctree::
    :maxdepth: 1

--- a/pennylane_qiskit/__init__.py
+++ b/pennylane_qiskit/__init__.py
@@ -17,6 +17,7 @@ from ._version import __version__
 from .aer import AerDevice
 from .basic_aer import BasicAerDevice
 from .ibmq import IBMQDevice
+from .generic import GenericDevice
 from .converter import load, load_qasm, load_qasm_from_file
 from .runtime_devices import IBMQCircuitRunnerDevice
 from .runtime_devices import IBMQSamplerDevice

--- a/pennylane_qiskit/__init__.py
+++ b/pennylane_qiskit/__init__.py
@@ -17,7 +17,7 @@ from ._version import __version__
 from .aer import AerDevice
 from .basic_aer import BasicAerDevice
 from .ibmq import IBMQDevice
-from .generic import GenericDevice
+from .remote import RemoteDevice
 from .converter import load, load_qasm, load_qasm_from_file
 from .runtime_devices import IBMQCircuitRunnerDevice
 from .runtime_devices import IBMQSamplerDevice

--- a/pennylane_qiskit/generic.py
+++ b/pennylane_qiskit/generic.py
@@ -1,0 +1,43 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module contains the :class:`~.GenericDevice` class, a PennyLane device that allows
+evaluation and differentiation on any Qiskit backend using Pennylane.
+"""
+
+from .qiskit_device import QiskitDevice
+
+
+class GenericDevice(QiskitDevice):
+    """A PennyLane device for any Qiskit backend.
+
+    Args:
+        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['ancilla', 'q1', 'q2']``).
+        provider (Provider | None): provider to lookup the backend on (ignored if a backend instance is passed).
+        backend (str | Backend): the desired backend. Either a name to look up on a provider, or a
+            BackendV1 or BackendV2 instance.
+        shots (int or None): number of circuit evaluations/random samples used
+            to estimate expectation values and variances of observables. For statevector backends,
+            setting to ``None`` results in computing statistics like expectation values and variances analytically.
+
+    Keyword Args:
+        name (str): The name of the circuit. Default ``'circuit'``.
+    """
+
+    short_name = "qiskit.generic"
+
+    def __init__(self, wires, backend, provider=None, shots=1024, **kwargs):
+        super().__init__(wires, provider=provider, backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -90,7 +90,7 @@ QISKIT_OPERATION_INVERSES_MAP = {
 def _get_backend_name(backend):
     try:
         return backend.name()  # BackendV1
-    except TypeError:
+    except TypeError:  # pragma: no cover
         return backend.name  # BackendV2
 
 
@@ -476,7 +476,8 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
         try:
             result = self._current_job.result(timeout=timeout)
-        except TypeError:  # timeout not supported
+        except TypeError:  # pragma: no cover
+            # timeout not supported
             result = self._current_job.result()
 
         # increment counter for number of executions of qubit device

--- a/pennylane_qiskit/remote.py
+++ b/pennylane_qiskit/remote.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Xanadu Quantum Technologies Inc.
+# Copyright 2023 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane_qiskit/remote.py
+++ b/pennylane_qiskit/remote.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This module contains the :class:`~.GenericDevice` class, a PennyLane device that allows
+This module contains the :class:`~.RemoteDevice` class, a PennyLane device that allows
 evaluation and differentiation on any Qiskit backend using Pennylane.
 """
 
 from .qiskit_device import QiskitDevice
 
 
-class GenericDevice(QiskitDevice):
+class RemoteDevice(QiskitDevice):
     """A PennyLane device for any Qiskit backend.
 
     Args:
@@ -37,7 +37,7 @@ class GenericDevice(QiskitDevice):
         name (str): The name of the circuit. Default ``'circuit'``.
     """
 
-    short_name = "qiskit.generic"
+    short_name = "qiskit.remote"
 
     def __init__(self, wires, backend, provider=None, shots=1024, **kwargs):
         super().__init__(wires, provider=provider, backend=backend, shots=shots, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ info = {
     ],
     'entry_points': {
         'pennylane.plugins': [
-            'qiskit.generic = pennylane_qiskit:GenericDevice',
+            'qiskit.remote = pennylane_qiskit:RemoteDevice',
             'qiskit.aer = pennylane_qiskit:AerDevice',
             'qiskit.basicaer = pennylane_qiskit:BasicAerDevice',
             'qiskit.ibmq = pennylane_qiskit:IBMQDevice',

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ info = {
     ],
     'entry_points': {
         'pennylane.plugins': [
+            'qiskit.generic = pennylane_qiskit:GenericDevice',
             'qiskit.aer = pennylane_qiskit:AerDevice',
             'qiskit.basicaer = pennylane_qiskit:BasicAerDevice',
             'qiskit.ibmq = pennylane_qiskit:IBMQDevice',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,8 +34,8 @@ class TestDeviceIntegration:
         assert dev.capabilities()["returns_state"] == (backend in state_backends)
 
     @pytest.mark.parametrize("d", pldevices)
-    def test_load_generic_device_with_backend_instance(self, d, backend):
-        """Test that the qiskit.generic device loads correctly when passed a backend instance."""
+    def test_load_remote_device_with_backend_instance(self, d, backend):
+        """Test that the qiskit.remote device loads correctly when passed a backend instance."""
         _, provider = d
 
         try:
@@ -43,17 +43,17 @@ class TestDeviceIntegration:
         except QiskitBackendNotFoundError:
             pytest.skip("Only the AerSimulator is supported on AerDevice")
 
-        dev = qml.device("qiskit.generic", wires=2, backend=backend_instance, shots=1024)
+        dev = qml.device("qiskit.remote", wires=2, backend=backend_instance, shots=1024)
         assert dev.num_wires == 2
         assert dev.shots == 1024
-        assert dev.short_name == "qiskit.generic"
+        assert dev.short_name == "qiskit.remote"
         assert dev.provider is None
         assert dev.capabilities()["returns_state"] == (backend in state_backends)
 
     @pytest.mark.parametrize("d", pldevices)
-    def test_load_generic_device_by_name(self, d, backend):
-        """Test that the qiskit.generic device loads correctly when passed a provider and a backend
-        name. This test is equivalent to `test_load_device` but on the qiskit.generic device instead
+    def test_load_remote_device_by_name(self, d, backend):
+        """Test that the qiskit.remote device loads correctly when passed a provider and a backend
+        name. This test is equivalent to `test_load_device` but on the qiskit.remote device instead
         of specialized devices that expose more configuration options."""
         _, provider = d
 
@@ -62,10 +62,10 @@ class TestDeviceIntegration:
         ):
             pytest.skip("Only the AerSimulator is supported on AerDevice")
 
-        dev = qml.device("qiskit.generic", wires=2, provider=provider, backend=backend, shots=1024)
+        dev = qml.device("qiskit.remote", wires=2, provider=provider, backend=backend, shots=1024)
         assert dev.num_wires == 2
         assert dev.shots == 1024
-        assert dev.short_name == "qiskit.generic"
+        assert dev.short_name == "qiskit.remote"
         assert dev.provider == provider
         assert dev.capabilities()["returns_state"] == (backend in state_backends)
 
@@ -81,11 +81,11 @@ class TestDeviceIntegration:
         ):
             qml.device("qiskit.aer", wires=100, method="statevector")
 
-    def test_generic_device_no_provider(self):
-        """Test that the qiskit.generic device raises a ValueError if passed a backend
+    def test_remote_device_no_provider(self):
+        """Test that the qiskit.remote device raises a ValueError if passed a backend
         by name but no provider to look up the name on."""
         with pytest.raises(ValueError, match=r"Must pass a provider"):
-            qml.device("qiskit.generic", wires=2, backend="aer_simulator_statevector")
+            qml.device("qiskit.remote", wires=2, backend="aer_simulator_statevector")
 
     def test_args(self):
         """Test that the device requires correct arguments"""


### PR DESCRIPTION
This patch introduces a new `qiskit.generic` device that accepts instantiated Qiskit backends and wraps them into a Pennylane device.

This offers a more composable mechanism for specifying the Qiskit backend, especially for providers that require more filter criteria than only a name to select a unique backend with [`get_backend`](https://qiskit.org/documentation/stubs/qiskit.providers.ProviderV1.get_backend.html#qiskit.providers.ProviderV1.get_backend).

Basic integration tests were added.

A small patch on the call to `JobV1.result()` was done: changes in #298 pass a `timeout` argument to [`JobV1.result()`](https://qiskit.org/documentation/stubs/qiskit.providers.JobV1.result.html#qiskit.providers.JobV1.result). While supported by many job handles, including that from IBMQ, it is *not* part of the ABC definition and is therefore not required to be valid.