### PR TITLE
Include qubit gates from `pennylane.ops.op_math` in the converter.

### DIFF
--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -25,7 +25,7 @@ from qiskit.exceptions import QiskitError
 from sympy import lambdify
 
 import pennylane as qml
-import pennylane.ops.qubit as pennylane_ops
+import pennylane.ops as pennylane_ops
 from pennylane_qiskit.qiskit_device import QISKIT_OPERATION_MAP
 
 # pylint: disable=too-many-instance-attributes
@@ -188,7 +188,7 @@ def load(quantum_circuit: QuantumCircuit):
             # TODO: remove the following when gates have been renamed in PennyLane
             instruction_name = "U3Gate" if instruction_name == "UGate" else instruction_name
 
-            if instruction_name in inv_map and inv_map[instruction_name] in pennylane_ops.ops:
+            if instruction_name in inv_map and inv_map[instruction_name] in pennylane_ops._qubit__ops__:
                 # Extract the bound parameters from the operation. If the bound parameters are a
                 # Qiskit ParameterExpression, then replace it with the corresponding PennyLane
                 # variable from the var_ref_map dictionary.

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -188,6 +188,7 @@ def load(quantum_circuit: QuantumCircuit):
             # TODO: remove the following when gates have been renamed in PennyLane
             instruction_name = "U3Gate" if instruction_name == "UGate" else instruction_name
 
+            # pylint:disable=protected-access
             if (
                 instruction_name in inv_map
                 and inv_map[instruction_name] in pennylane_ops._qubit__ops__

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -188,7 +188,10 @@ def load(quantum_circuit: QuantumCircuit):
             # TODO: remove the following when gates have been renamed in PennyLane
             instruction_name = "U3Gate" if instruction_name == "UGate" else instruction_name
 
-            if instruction_name in inv_map and inv_map[instruction_name] in pennylane_ops._qubit__ops__:
+            if (
+                instruction_name in inv_map
+                and inv_map[instruction_name] in pennylane_ops._qubit__ops__
+            ):
                 # Extract the bound parameters from the operation. If the bound parameters are a
                 # Qiskit ParameterExpression, then replace it with the corresponding PennyLane
                 # variable from the var_ref_map dictionary.


### PR DESCRIPTION
When converting a Qiskit circuit to a PennyLane circuit a list of supported gates in PennyLane is required. This was previously given by the set `pennylane.ops.qubit.ops`. `CZ` was recently moved (https://github.com/PennyLaneAI/pennylane/pull/4117) to `pennylane.ops.op_math`, which lead to `CZ` not being one of the supported gates.

By replacing the current list of supported gates with `pennylane.ops._qubit__ops__` this issue is fixed.