### PR TITLE
fix the ensemble classification demo thumbnail

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -80,7 +80,7 @@ Check out these demos to see the PennyLane-Qiskit plugin in action:
 
 .. demogalleryitem::
     :name: Ensemble classification with Forest and Qiskit devices
-    :figure: _static/thumbs/ensemble_diagram.png
+    :figure: https://pennylane.ai/_images/ensemble_diagram.png
     :link:  https://pennylane.ai/qml/demos/ensemble_multi_qpu.html
     :tooltip: Use multiple QPUs to improve classification
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -80,9 +80,9 @@ Check out these demos to see the PennyLane-Qiskit plugin in action:
 
 .. demogalleryitem::
     :name: Ensemble classification with Forest and Qiskit devices
-    :figure: https://pennylane.ai/qml/_images/ensemble_diagram.png
+    :figure: _static/thumbs/ensemble_diagram.png
     :link:  https://pennylane.ai/qml/demos/ensemble_multi_qpu.html
-    :tooltip: Use multiple QPUs to improve classification.
+    :tooltip: Use multiple QPUs to improve classification
 
 .. demogalleryitem::
     :name: Quantum volume

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -210,8 +210,8 @@ def load(quantum_circuit: QuantumCircuit):
                             for i_ordered_params in ordered_params:
                                 f_args.append(var_ref_map.get(i_ordered_params))
                             pl_parameters.append(f(*f_args))
-                        else:
-                            pl_parameters.append(float(p))
+                        else:  # needed for qiskit<0.43.1
+                            pl_parameters.append(float(p))  # pragma: no cover
                     else:
                         pl_parameters.append(p)
 


### PR DESCRIPTION
the current one doesn't render because the extra `/qml`. Will also make this change in other plugins.

Also added the codecov ignore line, because that line of code is no longer needed in Qiskit >= 0.43.1 (explanation [here](https://qiskit.org/documentation/release_notes.html#upgrade-notes), tl;dr bound ParameterExpressions that represent floats now just get converted to floats, dropping the unnecessary wrapper)