### PR TITLE
remove test for removed functionality

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -373,7 +373,7 @@ class TestPLOperations:
 class TestPLTemplates:
     """Integration tests for checking certain PennyLane templates."""
 
-    def test_random_layers_tensor_unwrapped(self, monkeypatch):
+    def test_random_layers_tensor_unwrapped(self, mocker):
         """Test that if random_layer() receives a one element PennyLane tensor,
         then it is unwrapped successfully.
 
@@ -383,31 +383,24 @@ class TestPLTemplates:
         """
         dev = qml.device("qiskit.aer", wires=4)
 
-        lst = []
+        # spy on RandomLayers.compute_decomposition to make sure returned data is a tensor
+        spy = mocker.spy(qml.RandomLayers, "compute_decomposition")
 
-        # Mock function that accumulates gate parameters
-        mock_func = lambda par, wires: lst.append(par)
+        @qml.qnode(dev)
+        def circuit(phi=None):
+            qml.templates.layers.RandomLayers(phi, wires=list(range(4)))
+            return qml.expval(qml.PauliZ(0))
 
-        with monkeypatch.context() as m:
-            # Mock the gates used in RandomLayers
-            m.setattr(qml, "RX", mock_func)
-            m.setattr(qml, "RY", mock_func)
-            m.setattr(qml, "RZ", mock_func)
+        # RandomLayers loops over the random_layer function, with each call to random_layer
+        # being passed a `np.tensor` scalar.
+        phi = qml.numpy.tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
 
-            @qml.qnode(dev)
-            def circuit(phi=None):
-                qml.templates.layers.RandomLayers(phi, wires=list(range(4)))
-                return qml.expval(qml.PauliZ(0))
+        # Call the QNode, accumulate parameters
+        circuit(phi=phi)
 
-            # RandomLayers loops over the random_layer function, with each call to random_layer
-            # being passed a `np.tensor` scalar.
-            phi = qml.numpy.tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
-
-            # Call the QNode, accumulate parameters
-            circuit(phi=phi)
-
-            # Check parameters
-            assert all([isinstance(x, tensor) for x in lst])
+        # Check parameters
+        decomp_data = [d for op in spy.spy_return for d in op.data]
+        assert all([isinstance(x, tensor) for x in decomp_data])
 
     def test_tensor_unwrapped_gradient_no_error(self, monkeypatch):
         """Tests that the gradient calculation of a circuit that contains a

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -373,35 +373,6 @@ class TestPLOperations:
 class TestPLTemplates:
     """Integration tests for checking certain PennyLane templates."""
 
-    def test_random_layers_tensor_unwrapped(self, mocker):
-        """Test that if random_layer() receives a one element PennyLane tensor,
-        then it is unwrapped successfully.
-
-        The test involves using RandomLayers, which then calls random_layer
-        internally. Eventually each gate used by random_layer receives a single
-        scalar.
-        """
-        dev = qml.device("qiskit.aer", wires=4)
-
-        # spy on RandomLayers.compute_decomposition to make sure returned data is a tensor
-        spy = mocker.spy(qml.RandomLayers, "compute_decomposition")
-
-        @qml.qnode(dev)
-        def circuit(phi=None):
-            qml.templates.layers.RandomLayers(phi, wires=list(range(4)))
-            return qml.expval(qml.PauliZ(0))
-
-        # RandomLayers loops over the random_layer function, with each call to random_layer
-        # being passed a `np.tensor` scalar.
-        phi = qml.numpy.tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
-
-        # Call the QNode, accumulate parameters
-        circuit(phi=phi)
-
-        # Check parameters
-        decomp_data = [d for op in spy.spy_return for d in op.data]
-        assert all([isinstance(x, tensor) for x in decomp_data])
-
     def test_tensor_unwrapped_gradient_no_error(self, monkeypatch):
         """Tests that the gradient calculation of a circuit that contains a
         RandomLayers template taking a PennyLane tensor as differentiable


### PR DESCRIPTION
PennyLaneAI/pennylane#4355 changed the way tape expansion happens (particularly, the way operators are expanded via decomposition/queuing). Unfortunately, a pl-qiskit test depended on the old way, so [it failed](https://github.com/PennyLaneAI/plugin-test-matrix/actions/runs/5651144968/job/15308741680). It used to monkey-patch RX/RY/RZ but didn't fully replicate its behaviour.

~Instead, I'm using `mocker.spy` to spy on `RandomLayers.compute_decomposition`. It doesn't affect its behaviour, but it lets me see the returned operators, and this test just ensures that all operators in the decomposition still uses `qml.numpy.tensor` types for data (which I am still doing).~

EDIT: I am removing the test, because it was introduced with PennyLaneAI/pennylane#893 which is no longer a part of PL. Maybe some other tests should also be removed, but for now I'll leave it to this - they aren't hurting anyone