### PR TITLE
add qiskit-aer to setup.py

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,6 +9,7 @@ pybind11==2.9.2
 pygments==2.7.4
 pygments-github-lexers==0.0.5
 qiskit==0.42.1
+qiskit-aer==0.12.2
 qiskit-ibm-runtime==0.9.3
 qiskit-ibm-provider==0.5.2
 sphinxcontrib-bibtex==2.5.0

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ with open("README.rst", "r") as fh:
 
 requirements = [
     "qiskit>=0.32",
+    "qiskit-aer",
     "qiskit-ibm-runtime",
     "qiskit-ibm-provider",
     "mthree>=0.17",


### PR DESCRIPTION
CI [fails](https://github.com/PennyLaneAI/plugin-test-matrix/actions/runs/5686703893/job/15413953614) because `qiskit-aer` has [been removed](https://github.com/Qiskit/qiskit-metapackage/releases/tag/0.44.0) from `qiskit`, and now needs to be explicitly and separately installed.

Changes: I added `qiskit-aer` to `setup.py` and `doc/requirements.txt`. It's already in `requirements.txt`