### PR TITLE
Rename `QubitStateVector` to `StatePrep`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Improvements 🛠
 
+* Added support for `qml.StatePrep` as a state preparation operation.
+  [(#326)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/326)
+
 ### Breaking changes 💔
 
 ### Deprecations 👋
@@ -15,6 +18,8 @@
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Jay Soni,
 
 ---
 # Release 0.31.0

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -137,7 +137,7 @@ def execute_supported_operation(operation_name: str, parameters: list, wires: li
 
     if not parameters:
         operation(wires=wires)
-    elif operation_name == "StatePrep":
+    elif operation_name in ["QubitStateVector", "StatePrep"]:
         operation(np.array(parameters), wires=wires)
     else:
         operation(*parameters, wires=wires)

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -129,7 +129,7 @@ def execute_supported_operation(operation_name: str, parameters: list, wires: li
     """Utility function that executes an operation that is natively supported by PennyLane.
 
     Args:
-        operation_name (str): wires specified for the template
+        operation_name (str): Name of the PL operator to be executed
         parameters (str): parameters of the operation that will be executed
         wires (list): wires of the operation
     """
@@ -137,7 +137,7 @@ def execute_supported_operation(operation_name: str, parameters: list, wires: li
 
     if not parameters:
         operation(wires=wires)
-    elif operation_name == "QubitStateVector":
+    elif operation_name == "StatePrep":
         operation(np.array(parameters), wires=wires)
     else:
         operation(*parameters, wires=wires)

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -54,6 +54,7 @@ QISKIT_OPERATION_MAP_SELF_ADJOINT = {
     "CRZ": ex.CRZGate,
     "PhaseShift": ex.PhaseGate,
     "QubitStateVector": ex.Initialize,
+    "StatePrep": ex.Initialize,
     "Toffoli": ex.CCXGate,
     "QubitUnitary": ex.UnitaryGate,
     "U1": ex.U1Gate,
@@ -328,12 +329,12 @@ class QiskitDevice(QubitDevice, abc.ABC):
             split_op = operation.split("Adjoint(")
 
             if adjoint:
-                if split_op[1] in ("QubitUnitary)", "QubitStateVector)"):
+                if split_op[1] in ("QubitUnitary)", "QubitStateVector)", "StatePrep)"):
                     # Need to revert the order of the quantum registers used in
                     # Qiskit such that it matches the PennyLane ordering
                     qregs = list(reversed(qregs))
             else:
-                if split_op[0] in ("QubitUnitary", "QubitStateVector"):
+                if split_op[0] in ("QubitUnitary", "QubitStateVector", "StatePrep"):
                     # Need to revert the order of the quantum registers used in
                     # Qiskit such that it matches the PennyLane ordering
                     qregs = list(reversed(qregs))
@@ -348,18 +349,18 @@ class QiskitDevice(QubitDevice, abc.ABC):
         return circuits
 
     def qubit_state_vector_check(self, operation):
-        """Input check for the the QubitStateVector operation.
+        """Input check for the StatePrepBase operations.
 
         Args:
             operation (pennylane.Operation): operation to be checked
 
         Raises:
-            DeviceError: If the operation is QubitStateVector
+            DeviceError: If the operation is QubitStateVector or StatePrep
         """
-        if operation == "QubitStateVector":
+        if operation in ("QubitStateVector", "StatePrep"):
             if "unitary" in self.backend_name:
                 raise DeviceError(
-                    "The QubitStateVector operation "
+                    f"The {operation} operation "
                     "is not supported on the unitary simulator backend."
                 )
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
-pennylane>=0.30
+git+https://github.com/PennyLaneAI/pennylane.git
 qiskit
 mthree
 numpy

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1011,7 +1011,7 @@ class TestConverterIntegration:
 
         @qml.qnode(qubit_device_single_wire)
         def circuit_native_pennylane():
-            qml.QubitStateVector(np.array(prob_amplitudes), wires=[0])
+            qml.StatePrep(np.array(prob_amplitudes), wires=[0])
             return qml.expval(qml.PauliZ(0))
 
         assert circuit_loaded_qiskit_circuit() == circuit_native_pennylane()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -293,7 +293,7 @@ class TestPLOperations:
 
     @pytest.mark.parametrize("shots", [None, 1000])
     def test_rotation(self, init_state, state_vector_device, shots, tol):
-        """Test that the QubitStateVector and Rot operations are decomposed using a
+        """Test that the StatePrep and Rot operations are decomposed using a
         Qiskit device with statevector backend"""
 
         dev = state_vector_device(1)
@@ -319,7 +319,7 @@ class TestPLOperations:
 
         @qml.qnode(dev)
         def qubitstatevector_and_rot():
-            qml.QubitStateVector(state, wires=[0])
+            qml.StatePrep(state, wires=[0])
             qml.Rot(a, b, c, wires=[0])
             return qml.expval(qml.Identity(0))
 

--- a/tests/test_inverses.py
+++ b/tests/test_inverses.py
@@ -61,7 +61,7 @@ class TestInverses:
 
         @qml.qnode(dev)
         def circuit():
-            qml.QubitStateVector(np.array([1 / 2, 0, 0, math.sqrt(3) / 2]), wires=[0, 1])
+            qml.StatePrep(np.array([1 / 2, 0, 0, math.sqrt(3) / 2]), wires=[0, 1])
             qml.adjoint(op(wires=[0, 1]))
             return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
@@ -192,7 +192,7 @@ class TestInverses:
 
         @qml.qnode(dev)
         def circuit():
-            qml.QubitStateVector(np.array([1 / 2, 0, 0, math.sqrt(3) / 2]), wires=[0, 1])
+            qml.StatePrep(np.array([1 / 2, 0, 0, math.sqrt(3) / 2]), wires=[0, 1])
             qml.adjoint(op(*np.negative(par), wires=[0, 1]))
             return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 


### PR DESCRIPTION
Following the work [here](https://github.com/PennyLaneAI/pennylane/pull/4450/), we make sure that the pennylane-qiskit plugin supports both operators and defaults to using `StatePrep` where appropriate until it is deprecated.