### PR TITLE
remove mthree since it is not needed

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,6 @@ dc-qiskit-algorithms==0.0.14
 docutils==0.19
 ipykernel==6.22.0
 jinja2==3.0.3
-mthree==1.1.0
 nbsphinx==0.9.1
 pennylane==0.30.0
 pybind11==2.9.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,4 @@
 pennylane>=0.32
 qiskit
-mthree
 numpy
 sympy

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ dill==0.3.4
 future==0.18.3
 idna==3.3
 mpmath==1.2.1
-mthree==0.22.0
 networkx==3.1
 ninja==1.11.1
 ntlm-auth==1.5.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ requirements = [
     "qiskit-aer",
     "qiskit-ibm-runtime",
     "qiskit-ibm-provider",
-    "mthree>=0.17",
     "pennylane>=0.30",
     "numpy",
     "networkx>=2.2",


### PR DESCRIPTION
mthree was originally added for the VQE runner, which isn't around anymore. I want to remove it because it's messing with my local env. It requires `qiskit-ibmq-provider` which requires `numpy<1.24`, and those days are behind us.

note: numpy is still pinned to <1.24 on PL 0.32 (which this requires, but after the next release this might all change) so CI ran with that.