### PR TITLE
fix qiskit_device to support Aer v2 conventions

### DIFF
--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -155,13 +155,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
     def __init__(self, wires, provider, backend, shots=1024, **kwargs):
         super().__init__(wires=wires, shots=shots)
 
-        # Keep track if the user specified analytic to be True
-        if shots is None and backend not in self._state_backends:
-            # Raise a warning if no shots were specified for a hardware device
-            warnings.warn(self.hw_analytic_warning_message.format(backend), UserWarning)
-
-            self.shots = 1024
-
         self.provider = provider
 
         if isinstance(backend, Backend):
@@ -181,7 +174,14 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             self.backend_name = _get_backend_name(self._backend)
 
-        self._capabilities["returns_state"] = self.backend_name in self._state_backends
+        # Keep track if the user specified analytic to be True
+        if shots is None and not self._is_state_backend:
+            # Raise a warning if no shots were specified for a hardware device
+            warnings.warn(self.hw_analytic_warning_message.format(backend), UserWarning)
+
+            self.shots = 1024
+
+        self._capabilities["returns_state"] = self._is_state_backend
 
         # Perform validation against backend
         b = self.backend
@@ -224,6 +224,26 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
         # Consider the remaining kwargs as keyword arguments to run
         self.run_args.update(kwargs)
+
+    @property
+    def _is_state_backend(self):
+        """Returns whether this device has a state backend."""
+        return self.backend_name in self._state_backends or self.backend.options.get("method") in {
+            "unitary",
+            "statevector",
+        }
+
+    @property
+    def _is_statevector_backend(self):
+        """Returns whether this device has a statevector backend."""
+        method = "statevector"
+        return method in self.backend_name or self.backend.options.get("method") == method
+
+    @property
+    def _is_unitary_backend(self):
+        """Returns whether this device has a unitary backend."""
+        method = "unitary"
+        return method in self.backend_name or self.backend.options.get("method") == method
 
     def set_transpile_args(self, **kwargs):
         """The transpile argument setter.
@@ -278,7 +298,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         for circuit in applied_operations:
             self._circuit &= circuit
 
-        if self.backend_name not in self._state_backends:
+        if not self._is_state_backend:
             # Add measurements if they are needed
             for qr, cr in zip(self._reg, self._creg):
                 self._circuit.measure(qr, cr)
@@ -357,7 +377,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
             DeviceError: If the operation is QubitStateVector or StatePrep
         """
         if operation in ("QubitStateVector", "StatePrep"):
-            if "unitary" in self.backend_name:
+            if self._is_unitary_backend:
                 raise DeviceError(
                     f"The {operation} operation "
                     "is not supported on the unitary simulator backend."
@@ -382,7 +402,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         self._current_job = self.backend.run(qcirc, shots=self.shots, **self.run_args)
         result = self._current_job.result()
 
-        if self.backend_name in self._state_backends:
+        if self._is_state_backend:
             self._state = self._get_state(result)
 
     def _get_state(self, result, experiment=None):
@@ -395,10 +415,10 @@ class QiskitDevice(QubitDevice, abc.ABC):
         Returns:
             array[float]: size ``(2**num_wires,)`` statevector
         """
-        if "statevector" in self.backend_name:
+        if self._is_statevector_backend:
             state = np.asarray(result.get_statevector(experiment))
 
-        elif "unitary" in self.backend_name:
+        elif self._is_unitary_backend:
             unitary = np.asarray(result.get_unitary(experiment))
             initial_state = np.zeros([2**self.num_wires])
             initial_state[0] = 1
@@ -422,7 +442,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         """
 
         # branch out depending on the type of backend
-        if self.backend_name in self._state_backends:
+        if self._is_state_backend:
             # software simulator: need to sample from probabilities
             return super().generate_samples()
 
@@ -491,7 +511,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
                 self.tracker.update(executions=1, shots=self.shots)
                 self.tracker.record()
 
-            if self.backend_name in self._state_backends:
+            if self._is_state_backend:
                 self._state = self._get_state(result, experiment=circuit_obj)
 
             # generate computational basis samples

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -298,7 +298,7 @@ class TestPLOperations:
 
         dev = state_vector_device(1)
 
-        if "unitary" in dev.backend_name:
+        if dev._is_unitary_backend:
             pytest.skip("Test only runs for backends that are not the unitary simulator.")
 
         state = init_state(1)
@@ -480,7 +480,7 @@ class TestNoise:
         bit_flip = aer.noise.pauli_error([("X", 1), ("I", 0)])
 
         # Create a noise model where the RX operation always flips the bit
-        noise_model.add_all_qubit_quantum_error(bit_flip, ["z"])
+        noise_model.add_all_qubit_quantum_error(bit_flip, ["z", "rz"])
 
         dev = qml.device("qiskit.aer", wires=2, noise_model=noise_model)
 


### PR DESCRIPTION
Tests suddenly [began to fail](https://github.com/PennyLaneAI/plugin-test-matrix/actions/runs/6661145908/job/18103535073) with the release of Aer 0.13.0 yesterday. The main change is that it got upgraded to a V2 backend. The consequence is that we depended on the device name to check its behaviours.

Some code to highlight the change:
**Qiskit-Aer v0.12.2**
```pycon
>>> dev = qml.device("qiskit.aer", wires=2, backend="aer_simulator_unitary")
>>> dev.backend, dev.backend.options.method
(AerSimulator('aer_simulator_unitary'), 'unitary')
```

**Qiskit-Aer v0.13.0**
```pycon
>>> dev = qml.device("qiskit.aer", wires=2, backend="aer_simulator_unitary")
>>> dev.backend, dev.backend.options.method
(AerSimulator('aer_simulator'), 'unitary')
```

We often check things like `if some_method in dev.backend_name`, so I had to update those checks to be more general and support the new (and undocumented!) V2 backend naming convention used with Aer.

Test change: for some reason, transpilation of the circuit in that one test turned a PauliZ into an RZ(-pi), and we were only applying the noise to Z gates. I just added RZ to the list of gates we apply noise on to fix it.