### PR TITLE
Solved issue #337 (this fix also #267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,19 @@
 
 ### Bug fixes 🐛
 
+* In `IBMQSamplerDevice` the `generate_samples` function:
+  1. gets counts from the nearest probability distribution because 
+  the quasi-distribution may contain negative probabilities. 
+  2. Avoid indexing error. 
+  3. Returns the qubit with Pennylane convention instead of Qiskit convention.
+  [(#357)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/357)
+
+
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Francesco Scala
 
 ---
 # Release 0.33.1

--- a/pennylane_qiskit/runtime_devices.py
+++ b/pennylane_qiskit/runtime_devices.py
@@ -208,6 +208,7 @@ class IBMQSamplerDevice(IBMQDevice):
         probs = [0] * number_of_states
         # Fill in probabilities from counts: (state, prob) (e.g. ('010', 0.5))
         for state, prob in counts.items():
+            # Formatting all strings to the same lenght
             while len(state) < self.num_wires:
                 state = '0' + state[:]
             probs[int(state[::-1], 2)] = prob

--- a/pennylane_qiskit/runtime_devices.py
+++ b/pennylane_qiskit/runtime_devices.py
@@ -201,16 +201,20 @@ class IBMQSamplerDevice(IBMQDevice):
              array[complex]: array of samples in the shape ``(dev.shots, dev.num_wires)``
         """
         # We get nearest probability distribution because the quasi-distribution may contain negative probabilities
-        counts = self._current_job.quasi_dists[circuit_id].nearest_probability_distribution().binary_probabilities()
+        counts = (
+            self._current_job.quasi_dists[circuit_id]
+            .nearest_probability_distribution()
+            .binary_probabilities()
+        )
         # Since qiskit does not return padded string we need to recover the number of qubits with self.num_wires
-        number_of_states = 2 ** self.num_wires
+        number_of_states = 2**self.num_wires
         # Initialize probabilities to 0
         probs = [0] * number_of_states
         # Fill in probabilities from counts: (state, prob) (e.g. ('010', 0.5))
         for state, prob in counts.items():
             # Formatting all strings to the same lenght
             while len(state) < self.num_wires:
-                state = '0' + state[:]
+                state = "0" + state[:]
             # Inverting the order to recover Pennylane convention
             probs[int(state[::-1], 2)] = prob
         return self.states_to_binary(

--- a/pennylane_qiskit/runtime_devices.py
+++ b/pennylane_qiskit/runtime_devices.py
@@ -211,6 +211,7 @@ class IBMQSamplerDevice(IBMQDevice):
             # Formatting all strings to the same lenght
             while len(state) < self.num_wires:
                 state = '0' + state[:]
+            # Inverting the order to recover Pennylane convention
             probs[int(state[::-1], 2)] = prob
         return self.states_to_binary(
             self.sample_basis_states(number_of_states, probs), self.num_wires

--- a/pennylane_qiskit/runtime_devices.py
+++ b/pennylane_qiskit/runtime_devices.py
@@ -200,10 +200,7 @@ class IBMQSamplerDevice(IBMQDevice):
         Returns:
              array[complex]: array of samples in the shape ``(dev.shots, dev.num_wires)``
         """
-        # we recover a quasi-probability distribution, 
-        # which can have negative probabilities
-        old_counts = self._current_job.quasi_dists[circuit_id].binary_probabilities()
-        # we then transform it into the nearest probability distribution
+        # we get nearest probability distribution because the quasi-distribution may contain negative probabilities
         counts = self._current_job.quasi_dists[circuit_id].nearest_probability_distribution().binary_probabilities()
         
         # Calculate number of states by taking the length of the first key

--- a/pennylane_qiskit/runtime_devices.py
+++ b/pennylane_qiskit/runtime_devices.py
@@ -202,17 +202,14 @@ class IBMQSamplerDevice(IBMQDevice):
         """
         # we get nearest probability distribution because the quasi-distribution may contain negative probabilities
         counts = self._current_job.quasi_dists[circuit_id].nearest_probability_distribution().binary_probabilities()
-        
         # Calculate number of states by taking the length of the first key
         keys = list(counts.keys())
         number_of_states = 2 ** len(keys[0])
-        
         # Initialize probabilities to 0
         probs = [0] * number_of_states
         # Fill in probabilities from counts: (state, prob) (e.g. ('010', 0.5))
         for state, prob in counts.items():
-            probs[int(state, 2)] = prob
-
+            probs[int(state[::-1], 2)] = prob
         return self.states_to_binary(
             self.sample_basis_states(number_of_states, probs), self.num_wires
         )


### PR DESCRIPTION
This change to `runtime_devices.py` avoid negative probabilities in quasi probability distributions (issue #337). It also includes the changes proposed in issue #267 which are still not implemented in the plugin.