### PR TITLE
pass job_tags and session_id kwargs correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,16 @@
 
 ### Bug fixes 🐛
 
+* The kwargs `job_tags` and `session_id` are passed to the correct arguments in the 
+  `circuit_runner` device so that they will be used in the Qiskit backend; these 
+  were previously ignored.
+  [(#358)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/358)
+
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Lillian Frederiksen
 
 ---
 # Release 0.33.1

--- a/pennylane_qiskit/runtime_devices.py
+++ b/pennylane_qiskit/runtime_devices.py
@@ -67,11 +67,14 @@ class IBMQCircuitRunnerDevice(IBMQDevice):
             program_inputs[kwarg] = self.kwargs.get(kwarg)
 
         # Specify the backend.
-        options = {"backend": self.backend.name}
+        options = {"backend": self.backend.name,
+                   "job_tags": self.kwargs.get("job_tags")}
+
+        session_id = self.kwargs.get("session_id")
 
         # Send circuits to the cloud for execution by the circuit-runner program.
         job = self.runtime_service.run(
-            program_id="circuit-runner", options=options, inputs=program_inputs
+            program_id="circuit-runner", options=options, inputs=program_inputs, session_id=session_id,
         )
         self._current_job = job.result(decoder=RunnerResult)
 

--- a/pennylane_qiskit/runtime_devices.py
+++ b/pennylane_qiskit/runtime_devices.py
@@ -67,14 +67,16 @@ class IBMQCircuitRunnerDevice(IBMQDevice):
             program_inputs[kwarg] = self.kwargs.get(kwarg)
 
         # Specify the backend.
-        options = {"backend": self.backend.name,
-                   "job_tags": self.kwargs.get("job_tags")}
+        options = {"backend": self.backend.name, "job_tags": self.kwargs.get("job_tags")}
 
         session_id = self.kwargs.get("session_id")
 
         # Send circuits to the cloud for execution by the circuit-runner program.
         job = self.runtime_service.run(
-            program_id="circuit-runner", options=options, inputs=program_inputs, session_id=session_id,
+            program_id="circuit-runner",
+            options=options,
+            inputs=program_inputs,
+            session_id=session_id,
         )
         self._current_job = job.result(decoder=RunnerResult)
 


### PR DESCRIPTION
A user on the forum was trying to pass `job_tags` and `session_id` to the `circuit_runner` device, unsuccessfully. 

They were being included in generic runtime kwargs and passed to the runtime service in the `program_inputs` argument, which doesn't work; `job_tags` belongs in the `options` dictionary, and `session_id` is its own kwarg on `runtime_service.run`. Now they will be passed to the correct places.