### PR TITLE
Update ibm_tutorial image

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -97,7 +97,7 @@ Check out these demos to see the PennyLane-Qiskit plugin in action:
 
 .. demogalleryitem::
     :name: Using PennyLane with IBM's quantum devices and Qiskit
-    :figure: https://pennylane.ai/_images/thumbnail_tutorial_ibm_pennylane.png
+    :figure: https://pennylane.ai/_static/demonstration_assets/ibm_pennylane/thumbnail_tutorial_ibm_pennylane.png
     :link: https://pennylane.ai/qml/demos/ibm_pennylane
     :tooltip: Use IBM devices with PennyLane through the pennylane-qiskit plugin
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -85,13 +85,13 @@ Check out these demos to see the PennyLane-Qiskit plugin in action:
 
 .. demogalleryitem::
     :name: Ensemble classification with Forest and Qiskit devices
-    :figure: https://pennylane.ai/_images/ensemble_diagram.png
+    :figure: https://pennylane.ai/_static/demonstration_assets/ensemble_multi_qpu/ensemble_diagram.png
     :link:  https://pennylane.ai/qml/demos/ensemble_multi_qpu.html
     :tooltip: Use multiple QPUs to improve classification
 
 .. demogalleryitem::
     :name: Quantum volume
-    :figure: _static/quantum_volume_thumbnail.png
+    :figure: https://pennylane.ai/_static/demonstration_assets/quantum_volume/quantum_volume_thumbnail.png
     :link:  https://pennylane.ai/qml/demos/quantum_volume.html
     :tooltip: Learn how to compute the quantum volume of a quantum processor
 


### PR DESCRIPTION
Fixes the thumbnail for the IBM-PennyLane tutorial, and replaces the URIs for the thumbnail images for the other two demos with the latest locations. 

![image](https://github.com/PennyLaneAI/pennylane-qiskit/assets/50180049/6e03ab7a-df44-4c3d-9275-dc9b70ce44da)

![image](https://github.com/PennyLaneAI/pennylane-qiskit/assets/50180049/6b983fd0-5afc-40b0-8663-bd3696b6dac7)
