### PR TITLE
remove support for Adjoint so it decomposes

### DIFF
--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -36,7 +36,7 @@ from ._version import __version__
 SAMPLE_TYPES = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
 
 
-QISKIT_OPERATION_MAP_SELF_ADJOINT = {
+QISKIT_OPERATION_MAP = {
     # native PennyLane operations also native to qiskit
     "PauliX": ex.XGate,
     "PauliY": ex.YGate,
@@ -65,23 +65,12 @@ QISKIT_OPERATION_MAP_SELF_ADJOINT = {
     "IsingZZ": ex.RZZGate,
     "IsingYY": ex.RYYGate,
     "IsingXX": ex.RXXGate,
-}
-
-# Separate dictionary for the inverses as the operations dictionary needs
-# to be invertible for the conversion functionality to work
-QISKIT_OPERATION_MAP_NON_SELF_ADJOINT = {"S": ex.SGate, "T": ex.TGate, "SX": ex.SXGate}
-QISKIT_OPERATION_INVERSES_MAP_NON_SELF_ADJOINT = {
+    "S": ex.SGate,
+    "T": ex.TGate,
+    "SX": ex.SXGate
     "Adjoint(S)": ex.SdgGate,
     "Adjoint(T)": ex.TdgGate,
     "Adjoint(SX)": ex.SXdgGate,
-}
-
-QISKIT_OPERATION_MAP = {
-    **QISKIT_OPERATION_MAP_SELF_ADJOINT,
-    **QISKIT_OPERATION_MAP_NON_SELF_ADJOINT,
-}
-QISKIT_OPERATION_INVERSES_MAP = {
-    **QISKIT_OPERATION_INVERSES_MAP_NON_SELF_ADJOINT,
 }
 
 
@@ -121,7 +110,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         "tensor_observables": True,
         "inverse_operations": True,
     }
-    _operation_map = {**QISKIT_OPERATION_MAP, **QISKIT_OPERATION_INVERSES_MAP}
+    _operation_map = QISKIT_OPERATION_MAP
     _state_backends = {
         "statevector_simulator",
         "unitary_simulator",

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -67,7 +67,7 @@ QISKIT_OPERATION_MAP = {
     "IsingXX": ex.RXXGate,
     "S": ex.SGate,
     "T": ex.TGate,
-    "SX": ex.SXGate
+    "SX": ex.SXGate,
     "Adjoint(S)": ex.SdgGate,
     "Adjoint(T)": ex.TdgGate,
     "Adjoint(SX)": ex.SXdgGate,

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -67,10 +67,6 @@ QISKIT_OPERATION_MAP_SELF_ADJOINT = {
     "IsingXX": ex.RXXGate,
 }
 
-QISKIT_OPERATION_INVERSES_MAP_SELF_ADJOINT = {
-    "Adjoint(" + k + ")": v for k, v in QISKIT_OPERATION_MAP_SELF_ADJOINT.items()
-}
-
 # Separate dictionary for the inverses as the operations dictionary needs
 # to be invertible for the conversion functionality to work
 QISKIT_OPERATION_MAP_NON_SELF_ADJOINT = {"S": ex.SGate, "T": ex.TGate, "SX": ex.SXGate}
@@ -85,7 +81,6 @@ QISKIT_OPERATION_MAP = {
     **QISKIT_OPERATION_MAP_NON_SELF_ADJOINT,
 }
 QISKIT_OPERATION_INVERSES_MAP = {
-    **QISKIT_OPERATION_INVERSES_MAP_SELF_ADJOINT,
     **QISKIT_OPERATION_INVERSES_MAP_NON_SELF_ADJOINT,
 }
 
@@ -347,19 +342,10 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             qregs = [self._reg[i] for i in device_wires.labels]
 
-            adjoint = operation.startswith("Adjoint(")
-            split_op = operation.split("Adjoint(")
-
-            if adjoint:
-                if split_op[1] in ("QubitUnitary)", "QubitStateVector)", "StatePrep)"):
-                    # Need to revert the order of the quantum registers used in
-                    # Qiskit such that it matches the PennyLane ordering
-                    qregs = list(reversed(qregs))
-            else:
-                if split_op[0] in ("QubitUnitary", "QubitStateVector", "StatePrep"):
-                    # Need to revert the order of the quantum registers used in
-                    # Qiskit such that it matches the PennyLane ordering
-                    qregs = list(reversed(qregs))
+            if operation in ("QubitUnitary", "QubitStateVector", "StatePrep"):
+                # Need to revert the order of the quantum registers used in
+                # Qiskit such that it matches the PennyLane ordering
+                qregs = list(reversed(qregs))
 
             dag = circuit_to_dag(QuantumCircuit(self._reg, self._creg, name=""))
             gate = mapped_operation(*par)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -370,6 +370,25 @@ class TestPLOperations:
 
         assert np.allclose(np.abs(dev.state) ** 2, np.abs(expected_state) ** 2, **tol)
 
+    @pytest.mark.parametrize("shots", [None, 1000])
+    def test_adjoint(self, state_vector_device, shots, tol):
+
+        dev = state_vector_device(1)
+
+        if dev._is_unitary_backend:
+            pytest.skip("Test only runs for backends that are not the unitary simulator.")
+
+        x = 1.23
+
+        @qml.qnode(dev)
+        def rotate_back_and_forth():
+            qml.RX(x, 0)
+            qml.adjoint(qml.RX(x, 0))
+            return qml.expval(qml.PauliZ(0))
+
+        res = rotate_back_and_forth()
+
+        assert np.allclose(res, 1)
 
 class TestPLTemplates:
     """Integration tests for checking certain PennyLane templates."""


### PR DESCRIPTION
The Qiskit devices don't handle `Adjoint` since we removed `.inv` (with the exception of 3 gates with special implementations), but many `Adjoint` operators remained on the allowed operators list. Currently, `RX(1.23, 0)` and `Adjoint(RX(1.23, 0))` both apply `RX(1.23, 0)` on the device. 

This PR removes those, so they decompose in PL before being sent to the device, such that e.g. `Adjoint(RX(1.23, 0))` is applied as `RX(-1.23, 0)` . 

Fixes issue #396 