### PR TITLE
Support for measurements operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Improvements 🛠
 
+* Measurement operations are now added to the PennyLane template when a `QuantumCircuit`
+  is converted using `load`. Additionally, one can override any existing terminal
+  measurements by providing a list of PennyLane 
+  `measurements <https://docs.pennylane.ai/en/stable/introduction/measurements.html>`_ themselves.
+  [(#405)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/405)
+
 ### Breaking changes 💔
 
 ### Deprecations 👋
@@ -15,6 +21,8 @@
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Utkarsh Azad
 
 ---
 # Release 0.34.0

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -87,9 +87,7 @@ def _check_circuit_and_bind_parameters(
         QuantumCircuit: quantum circuit with bound parameters
     """
     if not isinstance(quantum_circuit, QuantumCircuit):
-        raise ValueError(
-            f"The circuit {quantum_circuit} is not a valid Qiskit QuantumCircuit."
-        )
+        raise ValueError(f"The circuit {quantum_circuit} is not a valid Qiskit QuantumCircuit.")
 
     if params is None:
         return quantum_circuit
@@ -230,8 +228,8 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
             elif isinstance(op, Measure):
                 meas_terminal = True
                 # Look-ahead for more gate(s) on its wire(s)
-                for meas_ix in range(idx, num_inst-1):
-                    (next_op, next_qargs, _), op_wires = qc.data[meas_ix+1], set(operation_wires)
+                for meas_ix in range(idx, num_inst - 1):
+                    (next_op, next_qargs, _), op_wires = qc.data[meas_ix + 1], set(operation_wires)
                     next_op_name = getattr(next_op, "base_class", next_op.__class__).__name__
                     if next_op_name not in ["Barrier", "GlobalPhaseGate"]:
                         next_op_wires = set(wire_map[hash(qubit)] for qubit in next_qargs)

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -153,6 +153,7 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
         function: the resulting PennyLane template
     """
 
+    # pylint:disable=fixme, inconsistent-return-statements, too-many-branches
     def _function(params: dict = None, wires: list = None):
         """Returns a PennyLane template created based on the input QuantumCircuit.
         Warnings are created for each of the QuantumCircuit instructions that were
@@ -186,7 +187,6 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
 
             # New Qiskit gates that are not natively supported by PL (identical
             # gates exist with a different name)
-            # pylint:disable=fixme
             # TODO: remove the following when gates have been renamed in PennyLane
             instruction_name = "U3Gate" if instruction_name == "UGate" else instruction_name
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -71,8 +71,6 @@ QISKIT_OPERATION_MAP = {
     "Adjoint(S)": ex.SdgGate,
     "Adjoint(T)": ex.TdgGate,
     "Adjoint(SX)": ex.SXdgGate,
-    "Barrier": ex.Barrier,
-    "GlobalPhase": ex.GlobalPhaseGate,
 }
 
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -71,6 +71,8 @@ QISKIT_OPERATION_MAP = {
     "Adjoint(S)": ex.SdgGate,
     "Adjoint(T)": ex.TdgGate,
     "Adjoint(SX)": ex.SXdgGate,
+    "Barrier": ex.Barrier,
+    "GlobalPhase": ex.GlobalPhaseGate,
 }
 
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1145,6 +1145,7 @@ class TestConverterIntegration:
         assert circuit_loaded_qiskit_circuit() == circuit_native_pennylane()
 
         quantum_circuit = load(qc, measurements=None)
+
         @qml.qnode(qubit_device_2_wires)
         def circuit_loaded_qiskit_circuit2():
             meas = quantum_circuit()

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -818,10 +818,9 @@ class TestConverterQasm:
 
         quantum_circuit = load_qasm_from_file(qft_qasm)
 
-        with pytest.warns(UserWarning) as record:
-            with recorder:
-                quantum_circuit()
-        print(recorder.queue)
+        with recorder:
+            quantum_circuit()
+
         assert len(recorder.queue) == 11
 
         assert recorder.queue[0].name == "PauliX"
@@ -872,9 +871,8 @@ class TestConverterQasm:
 
         quantum_circuit = load_qasm(qasm_string)
 
-        with pytest.warns(UserWarning) as record:
-            with recorder:
-                quantum_circuit(params={})
+        with recorder:
+            quantum_circuit(params={})
 
         assert len(recorder.queue) == 6
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1148,9 +1148,31 @@ class TestConverterIntegration:
         @qml.qnode(qubit_device_2_wires)
         def circuit_native_pennylane2():
             qml.Hadamard(0)
-            qml.measure(0)
+            m0 = qml.measure(0)
             qml.RZ(angle, wires=0)
             qml.CNOT([0, 1])
-            return [qml.expval(m) for m in [qml.measure(0), qml.measure(1)]]
+            return [qml.expval(m) for m in [m0, qml.measure(0), qml.measure(1)]]
 
         assert circuit_loaded_qiskit_circuit2() == circuit_native_pennylane2()
+
+    def test_diff_meas_circuit(self):
+        """Tests mid-measurements are recognized and returned correctly."""
+
+        angle = 0.543
+
+        qc = QuantumCircuit(3, 3)
+        qc.h(0)
+        qc.measure(0, 0)
+        qc.rx(angle, [0])
+        qc.cx(0, 1)
+        qc.measure(1, 1)
+
+        qc1 = QuantumCircuit(3, 3)
+        qc1.h(0)
+        qc1.measure(2, 2)
+        qc1.rx(angle, [0])
+        qc1.cx(0, 1)
+        qc1.measure(1, 1)
+
+        qtemp, qtemp1 = load(qc), load(qc1)
+        assert qtemp()[0] == qml.measure(0) and qtemp1()[0] == qml.measure(2)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1176,3 +1176,6 @@ class TestConverterIntegration:
 
         qtemp, qtemp1 = load(qc), load(qc1)
         assert qtemp()[0] == qml.measure(0) and qtemp1()[0] == qml.measure(2)
+
+        qtemp2 = load(qc, measurements=[qml.expval(qml.PauliZ(0))])
+        assert qtemp()[0] != qtemp2()[0] and qtemp2()[0] == qml.expval(qml.PauliZ(0))

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -821,7 +821,7 @@ class TestConverterQasm:
         with recorder:
             quantum_circuit()
 
-        assert len(recorder.queue) == 11
+        assert len(recorder.queue) == 10
 
         assert recorder.queue[0].name == "PauliX"
         assert recorder.queue[0].parameters == []
@@ -831,25 +831,21 @@ class TestConverterQasm:
         assert recorder.queue[1].parameters == []
         assert recorder.queue[1].wires == Wires([2])
 
-        assert recorder.queue[2].name == "Barrier"
+        assert recorder.queue[2].name == "Hadamard"
         assert recorder.queue[2].parameters == []
-        assert recorder.queue[2].wires == Wires([0, 1, 2, 3])
+        assert recorder.queue[2].wires == Wires([0])
 
         assert recorder.queue[3].name == "Hadamard"
         assert recorder.queue[3].parameters == []
-        assert recorder.queue[3].wires == Wires([0])
+        assert recorder.queue[3].wires == Wires([1])
 
         assert recorder.queue[4].name == "Hadamard"
         assert recorder.queue[4].parameters == []
-        assert recorder.queue[4].wires == Wires([1])
+        assert recorder.queue[4].wires == Wires([2])
 
         assert recorder.queue[5].name == "Hadamard"
         assert recorder.queue[5].parameters == []
-        assert recorder.queue[5].wires == Wires([2])
-
-        assert recorder.queue[6].name == "Hadamard"
-        assert recorder.queue[6].parameters == []
-        assert recorder.queue[6].wires == Wires([3])
+        assert recorder.queue[5].wires == Wires([3])
 
     def test_qasm_file_not_found_error(self):
         """Tests that an error is propagated, when a non-existing file is specified for parsing."""


### PR DESCRIPTION
This adds functionality to support measurements present in a qiskit's `QuantumCircuit` object or allows to override it using a keyword argument to the converter `load` function.

Example - 

``` py
# Building a Qiskit Circuit
qc = qk.QuantumCircuit(2, 2)
qc.h(0)
#qc.measure(0, 0)
qc.rz(0.543, [0])
qc.cx(0, 1)
qc.measure_all()

# Using the `load` functionality in PL
with qml.tape.OperationRecorder() as recorder:
    load(qc, measurements=None)()

>>> recorder.items()
((Hadamard(wires=[0]), {}),
 (measure(wires=[0]), {}),
 (RZ(0.543, wires=[0]), {}),
 (CNOT(wires=[0, 1]), {}),
 (Barrier(wires=[]), {}),
 (measure(wires=[0]), {}),
 (measure(wires=[1]), {}))

# Override it using the `keyword` argument
measurements = [qml.expval(qml.PauliZ(0)), qml.vn_entropy([0])]
with qml.tape.operation_recorder.AnnotatedQueue() as queue:
    load(qc, measurements=measurements)()
>>> queue
AnnotatedQueue([(Hadamard(wires=[0]), {}),
                (measure(wires=[0]), {}),
                (RZ(0.543, wires=[0]), {}),
                (CNOT(wires=[0, 1]), {}),
                (Barrier(wires=[]), {}),
                (expval(PauliZ(wires=[0])), {}),
                (vnentropy(wires=[0]), {})])


```