### PR TITLE
Revert changes for 0.46 and pin to <0.46

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,7 +7,7 @@ pennylane==0.34
 pybind11==2.11.1
 pygments==2.17.2
 pygments-github-lexers==0.0.5
-qiskit==0.46.0
+qiskit==0.45.3
 qiskit-aer==0.13.2
 qiskit-ibm-runtime==0.17.0
 qiskit-ibm-provider==0.7.3

--- a/pennylane_qiskit/aer.py
+++ b/pennylane_qiskit/aer.py
@@ -60,6 +60,4 @@ class AerDevice(QiskitDevice):
         if method != "automatic":
             backend += "_" + method
 
-        super().__init__(
-            wires, provider=qiskit_aer.AerProvider(), backend=backend, shots=shots, **kwargs
-        )
+        super().__init__(wires, provider=qiskit_aer.Aer, backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -16,7 +16,7 @@ This module contains the :class:`~.BasicAerDevice` class, a PennyLane device tha
 evaluation and differentiation of Qiskit Terra's BasicAer simulator
 using PennyLane.
 """
-import qiskit_aer
+import qiskit
 
 from .qiskit_device import QiskitDevice
 
@@ -51,6 +51,4 @@ class BasicAerDevice(QiskitDevice):
     short_name = "qiskit.basicaer"
 
     def __init__(self, wires, shots=1024, backend="qasm_simulator", **kwargs):
-        super().__init__(
-            wires, provider=qiskit_aer.AerProvider(), backend=backend, shots=shots, **kwargs
-        )
+        super().__init__(wires, provider=qiskit.BasicAer, backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -99,6 +99,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         compile_backend (BaseBackend): The backend used for compilation. If you wish
             to simulate a device compliant circuit, you can specify a backend here.
     """
+
     name = "Qiskit PennyLane plugin"
     pennylane_requires = ">=0.30.0"
     version = __version__

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -99,7 +99,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
         compile_backend (BaseBackend): The backend used for compilation. If you wish
             to simulate a device compliant circuit, you can specify a backend here.
     """
-
     name = "Qiskit PennyLane plugin"
     pennylane_requires = ">=0.30.0"
     version = __version__

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ psutil==5.9.7
 pycparser==2.21
 python-constraint==1.4.0
 python-dateutil==2.8.2
-qiskit==0.46.0
+qiskit==0.45.3
 qiskit-aer==0.13.2
 qiskit-ibm-runtime==0.17.0
 qiskit-ibm-provider==0.7.3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 requirements = [
-    "qiskit>=0.32",
+    "qiskit>=0.32,<0.46",
     "qiskit-aer",
     "qiskit-ibm-runtime",
     "qiskit-ibm-provider",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -390,6 +390,7 @@ class TestPLOperations:
 
         assert np.allclose(res, 1)
 
+
 class TestPLTemplates:
     """Integration tests for checking certain PennyLane templates."""
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,7 +13,7 @@ from qiskit.providers import QiskitBackendNotFoundError
 
 from conftest import state_backends
 
-pldevices = [("qiskit.aer", aer.AerProvider()), ("qiskit.basicaer", aer.AerProvider())]
+pldevices = [("qiskit.aer", aer.Aer), ("qiskit.basicaer", qiskit.BasicAer)]
 
 
 class TestDeviceIntegration:
@@ -202,6 +202,12 @@ class TestKeywordArguments:
             dev = qml.device("qiskit.aer", wires=2, noise_model="test value")
         assert cache[-1] == {"noise_model": "test value"}
 
+    def test_invalid_noise_model(self):
+        """Test that the noise model argument causes an exception to be raised
+        if the backend does not support it"""
+        with pytest.raises(AttributeError, match="field noise_model is not valid for this backend"):
+            dev = qml.device("qiskit.basicaer", wires=2, noise_model="test value")
+
     def test_overflow_kwargs(self):
         """Test all overflow kwargs are extracted for the AerDevice"""
         dev = qml.device("qiskit.aer", wires=2, k1="v1", k2="v2")
@@ -383,7 +389,6 @@ class TestPLOperations:
         res = rotate_back_and_forth()
 
         assert np.allclose(res, 1)
-
 
 class TestPLTemplates:
     """Integration tests for checking certain PennyLane templates."""

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -14,14 +14,6 @@ test_transpile_options = [
 
 test_device_options = [{}, {"optimization_level": 3}, {"optimization_level": 1}]
 
-state_backends = [
-    "statevector_simulator",
-    "unitary_simulator",
-    "aer_simulator_statevector",
-    "aer_simulator_unitary",
-]
-hw_backends = ["qasm_simulator", "aer_simulator"]
-
 
 class TestProbabilities:
     """Tests for the probability function"""
@@ -57,18 +49,14 @@ class TestTranspilationOptionInitialization:
 class TestAnalyticWarningHWSimulator:
     """Tests the warnings for when the analytic attribute of a device is set to true"""
 
-    @pytest.mark.xfail(
-        reason="expected to fail until we take care of all the 0.46 warnings - len(record) != 1"
-    )
-    @pytest.mark.parametrize("backend", hw_backends)
-    def test_warning_raised_for_hardware_backend_analytic_expval(self, backend, recorder):
+    def test_warning_raised_for_hardware_backend_analytic_expval(self, hardware_backend, recorder):
         """Tests that a warning is raised if the analytic attribute is true on
         hardware simulators when calculating the expectation"""
-        if "aer" in backend:
+        if "aer" in hardware_backend:
             pytest.skip("Not supported on basicaer")
 
         with pytest.warns(UserWarning) as record:
-            dev = qml.device("qiskit.basicaer", backend=backend, wires=2, shots=None)
+            dev = qml.device("qiskit.basicaer", backend=hardware_backend, wires=2, shots=None)
 
         # check that only one warning was raised
         assert len(record) == 1
@@ -80,19 +68,15 @@ class TestAnalyticWarningHWSimulator:
             "device are estimates based on samples.".format(dev.backend)
         )
 
-    @pytest.mark.xfail(
-        reason="expected to fail until we take care of all the 0.46 warnings - len(record) != 1"
-    )
-    @pytest.mark.parametrize("backend", state_backends)
     def test_no_warning_raised_for_software_backend_analytic_expval(
-        self, backend, recorder, recwarn
+        self, statevector_backend, recorder, recwarn
     ):
         """Tests that no warning is raised if the analytic attribute is true on
         statevector simulators when calculating the expectation"""
         if "aer" in statevector_backend:
             pytest.skip("Not supported on basicaer")
 
-        dev = qml.device("qiskit.basicaer", backend=backend, wires=2, shots=None)
+        dev = qml.device("qiskit.basicaer", backend=statevector_backend, wires=2, shots=None)
 
         # check that no warnings were raised
         assert len(recwarn) == 0


### PR DESCRIPTION
We are waiting a few weeks for the update to compatibility with 0.46/1.0, and continuing with interoperability tasks first. For the 0.35 release, we will pin to `qiskit <0.46`. 

This reverts the changes we've made so far to accomodate deprecations in 0.46. They are preserved in the `deprecation_warnings` branch.