### PR TITLE
Pin qiskit to less than 1.0

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 pennylane>=0.32
-qiskit
+qiskit<1.0
 numpy
 sympy


### PR DESCRIPTION
Integration tests are not ready for 1.0. The goal for 1.0 compatibility is the release after this one. But 1.0 was released and now tests are failing.