### PR TITLE
Qiskit 1.0 compatibility for 0.35

### DIFF
--- a/.github/workflows/tests_qiskit_1.yml
+++ b/.github/workflows/tests_qiskit_1.yml
@@ -1,0 +1,50 @@
+name: Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.9, '3.10', '3.11']
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-ci0.txt
+          pip install wheel pytest pytest-cov pytest-mock flaky --upgrade
+
+      - name: Install Plugin
+        run: |
+          python setup.py bdist_wheel
+          pip install dist/PennyLane*.whl
+
+      - name: Run Qiskit converter tests
+        # Test conversion to PennyLane with Qiskit 1.0.0
+        run: python -m pytest tests/test_converter.py
+        env:
+          IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN_TEST }}
+
+      - name: Run temporary tests
+        # tests that test intermediate functionality, will be removed when everything is fully compatible with 1.0
+        run: python -m pytest tests/test_new_qiskit_temp.py
+        env:
+          IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN_TEST }}

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -22,6 +22,7 @@ import inspect
 import warnings
 
 import numpy as np
+import qiskit
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.circuit import library as lib
 from qiskit.compiler import transpile
@@ -141,6 +142,13 @@ class QiskitDevice(QubitDevice, abc.ABC):
     _eigs = {}
 
     def __init__(self, wires, provider, backend, shots=1024, **kwargs):
+
+        if qiskit.__version__ in ["0.46.0", "1.0.0"]:
+            raise RuntimeError(f"The devices in the PennyLane Qiskit plugin are currently only compatible "
+                               f"with version of Qiskit below 0.46. It looks like you have {qiskit.__version__} "
+                               f"installed. Please downgrade to use the devices. The devices will be updated "
+                               f"in the coming weeks to be compatible with Qiskit 1.0!")
+
         super().__init__(wires=wires, shots=shots)
 
         self.provider = provider

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -23,7 +23,7 @@ import warnings
 
 import numpy as np
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit import extensions as ex
+from qiskit.circuit import library as lib
 from qiskit.compiler import transpile
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.providers import Backend, QiskitBackendNotFoundError
@@ -38,39 +38,39 @@ SAMPLE_TYPES = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
 
 QISKIT_OPERATION_MAP = {
     # native PennyLane operations also native to qiskit
-    "PauliX": ex.XGate,
-    "PauliY": ex.YGate,
-    "PauliZ": ex.ZGate,
-    "Hadamard": ex.HGate,
-    "CNOT": ex.CXGate,
-    "CZ": ex.CZGate,
-    "SWAP": ex.SwapGate,
-    "ISWAP": ex.iSwapGate,
-    "RX": ex.RXGate,
-    "RY": ex.RYGate,
-    "RZ": ex.RZGate,
-    "Identity": ex.IGate,
-    "CSWAP": ex.CSwapGate,
-    "CRX": ex.CRXGate,
-    "CRY": ex.CRYGate,
-    "CRZ": ex.CRZGate,
-    "PhaseShift": ex.PhaseGate,
-    "QubitStateVector": ex.Initialize,
-    "StatePrep": ex.Initialize,
-    "Toffoli": ex.CCXGate,
-    "QubitUnitary": ex.UnitaryGate,
-    "U1": ex.U1Gate,
-    "U2": ex.U2Gate,
-    "U3": ex.U3Gate,
-    "IsingZZ": ex.RZZGate,
-    "IsingYY": ex.RYYGate,
-    "IsingXX": ex.RXXGate,
-    "S": ex.SGate,
-    "T": ex.TGate,
-    "SX": ex.SXGate,
-    "Adjoint(S)": ex.SdgGate,
-    "Adjoint(T)": ex.TdgGate,
-    "Adjoint(SX)": ex.SXdgGate,
+    "PauliX": lib.XGate,
+    "PauliY": lib.YGate,
+    "PauliZ": lib.ZGate,
+    "Hadamard": lib.HGate,
+    "CNOT": lib.CXGate,
+    "CZ": lib.CZGate,
+    "SWAP": lib.SwapGate,
+    "ISWAP": lib.iSwapGate,
+    "RX": lib.RXGate,
+    "RY": lib.RYGate,
+    "RZ": lib.RZGate,
+    "Identity": lib.IGate,
+    "CSWAP": lib.CSwapGate,
+    "CRX": lib.CRXGate,
+    "CRY": lib.CRYGate,
+    "CRZ": lib.CRZGate,
+    "PhaseShift": lib.PhaseGate,
+    "QubitStateVector": lib.Initialize,
+    "StatePrep": lib.Initialize,
+    "Toffoli": lib.CCXGate,
+    "QubitUnitary": lib.UnitaryGate,
+    "U1": lib.U1Gate,
+    "U2": lib.U2Gate,
+    "U3": lib.U3Gate,
+    "IsingZZ": lib.RZZGate,
+    "IsingYY": lib.RYYGate,
+    "IsingXX": lib.RXXGate,
+    "S": lib.SGate,
+    "T": lib.TGate,
+    "SX": lib.SXGate,
+    "Adjoint(S)": lib.SdgGate,
+    "Adjoint(T)": lib.TdgGate,
+    "Adjoint(SX)": lib.SXdgGate,
 }
 
 

--- a/requirements-ci0.txt
+++ b/requirements-ci0.txt
@@ -1,4 +1,4 @@
 pennylane>=0.32
-qiskit<1.0
+qiskit
 numpy
 sympy

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 requirements = [
-    "qiskit>=0.32,<0.46",
+    "qiskit>=0.32",
     "qiskit-aer",
     "qiskit-ibm-runtime",
     "qiskit-ibm-provider",

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -3,7 +3,7 @@ import sys
 
 import pytest
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit import extensions as ex
+from qiskit.circuit import library as lib
 from qiskit.circuit import Parameter
 from qiskit.circuit.library import EfficientSU2
 from qiskit.exceptions import QiskitError
@@ -212,7 +212,7 @@ class TestConverter:
 
         qc = QuantumCircuit(3, 1)
         qc.rz(theta, [0])
-        qc_1 = qc.bind_parameters({theta: 0.5})
+        qc_1 = qc.assign_parameters({theta: 0.5})
 
         quantum_circuit = load(qc_1)
 
@@ -686,7 +686,7 @@ class TestConverterGates:
 
         assert recorder.queue[0].name == "QubitUnitary"
         assert len(recorder.queue[0].parameters) == 1
-        assert np.array_equal(recorder.queue[0].parameters[0], ex.CHGate().to_matrix())
+        assert np.array_equal(recorder.queue[0].parameters[0], lib.CHGate().to_matrix())
         assert recorder.queue[0].wires == Wires([0, 1])
 
 

--- a/tests/test_new_qiskit_temp.py
+++ b/tests/test_new_qiskit_temp.py
@@ -1,0 +1,14 @@
+import pytest
+import pennylane as qml
+import qiskit
+
+def test_error_is_raised_if_initalizing_device():
+    """Test that when Qiskit 1.0 is installed, an error is raised if you try
+    to initialize a device. This is a temporary test and will be removed along
+    with the error one everything is compatible with 1.0"""
+    if qiskit.__version__ != "1.0.0":
+        pass
+
+    else:
+        with pytest.raises(RuntimeError, match="The devices in the PennyLane Qiskit plugin are currently only compatible with version of Qiskit below 0.46"):
+            qml.device("qiskit.aer", wires=2)


### PR DESCRIPTION
Initial changes for 0.35 with 1.0. 

Iteroperability/conversion from Qiskit to PennyLane should work with 1.0. A few small changes are made here to accomodate that, and a workflow is added to test it.

Device functionality will not be supported until the following release, so using a device raises an error saying the Qiskit version is too high.