### PR TITLE
Gracefully handle batch execution of no circuits

### DIFF
--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -496,6 +496,10 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
         compiled_circuits = self.compile_circuits(circuits)
 
+        if not compiled_circuits:
+            # At least one circuit must always be provided to the backend.
+            return []
+
         # Send the batch of circuit objects using backend.run
         self._current_job = self.backend.run(compiled_circuits, shots=self.shots, **self.run_args)
 

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -162,6 +162,16 @@ class TestBatchExecution:
         assert isinstance(res[1], np.ndarray)
         assert np.allclose(res[1], tape2_expected, atol=0)
 
+    def test_result_no_tapes(self, device):
+        """Tests that the result is correct when there are no tapes to execute."""
+        dev = device(2)
+        res = dev.batch_execute([])
+
+        # We're calling device methods directly, need to reset before the next
+        # execution
+        dev.reset()
+        assert not res
+
     def test_result_empty_tape(self, device, tol):
         """Tests that the result has the correct shape and entry types for
         empty tapes."""


### PR DESCRIPTION
Recently, a [PR to PennyLane](https://github.com/PennyLaneAI/pennylane/pull/5243) was merged which changed the default caching behaviour and caused 

```
tests/test_integration.py::TestPLTemplates::test_tensor_unwrapped_gradient_no_error
```

to fail with

```
TypeError: bad input to run() function;circuits must be either circuits or schedules
```

The error stems from `QiskitDevice.batch_execute()` being called with an empty list of circuits.