### PR TITLE
Supporting disguised mid-circuit measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   two of the ``ControlFlowOp`` operations - ``IfElseOp`` and ``SwitchCaseOp`` when converting
   a ``QuantumCircuit`` using `load`.
   [(#417)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/417)
+  [(#465)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/465)
 
 * Qiskit's classical ``Expr`` conditionals can also be used with the supported
   ``ControlFlowOp`` operations.

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -488,21 +488,21 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
                 for next_op, next_qargs, next_cargs in qc.data[idx + 1 :]:
                     # Check if the subsequent conditional is measurement needing
                     if isinstance(next_op, ControlFlowOp):
-                        if set(next_cargs).intersection(op_cregs):
+                        if set(next_cargs) & op_cregs:
                             meas_terminal = False
                             break
                     elif next_op.condition:  # For legacy c_if
                         next_op_reg = next_op.condition[0]
                         if isinstance(next_op_reg, Clbit):
                             next_op_reg = [next_op_reg]
-                        if set(next_op_reg).intersection(op_cregs):
+                        if set(next_op_reg) & op_cregs:
                             meas_terminal = False
                             break
                     # Check if the subsequent next_op is measurement interfering
                     if not isinstance(next_op, (Barrier, GlobalPhaseGate)):
                         next_op_wires = set(wire_map[hash(qubit)] for qubit in next_qargs)
                         # Check if there's any overlapping wires
-                        if next_op_wires.intersection(op_wires):
+                        if next_op_wires & op_wires:
                             meas_terminal = False
                             break
 

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -499,7 +499,7 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
                             meas_terminal = False
                             break
                     # Check if the subsequent next_op is measurement interfering
-                    elif not isinstance(next_op, (Barrier, GlobalPhaseGate)):
+                    if not isinstance(next_op, (Barrier, GlobalPhaseGate)):
                         next_op_wires = set(wire_map[hash(qubit)] for qubit in next_qargs)
                         # Check if there's any overlapping wires
                         if next_op_wires.intersection(op_wires):

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -481,21 +481,21 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
                     operation_args = [np.array(operation_params)]
 
             elif isinstance(instruction, Measure):
-                # Store the current operation wires
-                op_wires = set(operation_wires)
+                # Store the current operation wires and registers
+                op_wires, op_cregs = set(operation_wires), set(cargs)
                 # Look-ahead for more gate(s) on its wire(s)
                 meas_terminal = True
                 for next_op, next_qargs, next_cargs in qc.data[idx + 1 :]:
                     # Check if the subsequent conditional is measurement needing
                     if isinstance(next_op, ControlFlowOp):
-                        if set(next_cargs).intersection(set(cargs)):
+                        if set(next_cargs).intersection(op_cregs):
                             meas_terminal = False
                             break
                     elif next_op.condition:  # For legacy c_if
                         next_op_reg = next_op.condition[0]
                         if isinstance(next_op_reg, Clbit):
                             next_op_reg = [next_op_reg]
-                        if set(next_op_reg).intersection(set(cargs)):
+                        if set(next_op_reg).intersection(op_cregs):
                             meas_terminal = False
                             break
                     # Check if the subsequent next_op is measurement interfering

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -485,9 +485,21 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
                 op_wires = set(operation_wires)
                 # Look-ahead for more gate(s) on its wire(s)
                 meas_terminal = True
-                for next_op, next_qargs, __ in qc.data[idx + 1 :]:
-                    # Check if the subsequent whether next_op is measurement interfering
-                    if not isinstance(next_op, (Barrier, GlobalPhaseGate)):
+                for next_op, next_qargs, next_cargs in qc.data[idx + 1 :]:
+                    # Check if the subsequent conditional is measurement needing
+                    if isinstance(next_op, ControlFlowOp):
+                        if set(next_cargs).intersection(set(cargs)):
+                            meas_terminal = False
+                            break
+                    elif next_op.condition:  # For legacy c_if
+                        next_op_reg = next_op.condition[0]
+                        if isinstance(next_op_reg, Clbit):
+                            next_op_reg = [next_op_reg]
+                        if set(next_op_reg).intersection(set(cargs)):
+                            meas_terminal = False
+                            break
+                    # Check if the subsequent next_op is measurement interfering
+                    elif not isinstance(next_op, (Barrier, GlobalPhaseGate)):
                         next_op_wires = set(wire_map[hash(qubit)] for qubit in next_qargs)
                         # Check if there's any overlapping wires
                         if next_op_wires.intersection(op_wires):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1756,6 +1756,53 @@ class TestControlOpIntegration:
 
         assert np.allclose(qnode(0.543), circuit_native_pennylane(0.543))
 
+    def test_mid_circuit_as_terminal(self):
+        """Test the control workflows where mid-circuit measurements disguise as terminal ones"""
+
+        qc = QuantumCircuit(3, 2)
+
+        qc.rx(0.9, 0)  # Prepare input state on qubit 0
+
+        qc.h(1)  # Prepare Bell state on qubits 1 and 2
+        qc.cx(1, 2)
+
+        qc.cx(0, 1)  # Perform teleportation
+        qc.h(0)
+        qc.measure(0, 0)
+        qc.measure(1, 1)
+
+        with qc.if_test((0, 1)):
+            qc.x(2)
+
+        dev = qml.device("default.qubit", wires=3)
+
+        @qml.qnode(dev)
+        def qk_circuit():
+            qml.from_qiskit(qc)()
+            return qml.expval(qml.PauliZ(0))
+
+        @qml.qnode(dev)
+        def pl_circuit():
+            qml.RX(0.9, [0])
+            qml.Hadamard([1])
+            qml.CNOT([1, 2])
+            qml.CNOT([0, 1])
+            qml.Hadamard([0])
+            m0 = qml.measure(0)
+            qml.cond(m0 == 1, qml.PauliX)(wires=[2])
+            m1 = qml.measure(1)
+            return qml.expval(qml.PauliZ(0))
+
+        assert qk_circuit() == pl_circuit()
+        assert all(
+            (
+                op1 == op2
+                if not isinstance(op1, qml.measurements.MidMeasureMP)
+                else op1.wires == op2.wires
+            )
+            for op1, op2 in zip(qk_circuit.tape.operations, pl_circuit.tape.operations)
+        )
+
 
 class TestPassingParameters:
     def _get_parameter_vector_test_circuit(self, qubit_device_2_wires):


### PR DESCRIPTION
A mid-circuit measurement may appear to be terminal since no other operation happens on the wire, but in reality, it might be used for some upcoming controlled workflow elsewhere in the circuit. This adds a checking condition to catch such scenarios and treat those terminal measurements as mid-circuit measurements. 