### PR TITLE
Support loading Qiskit circuits with a single measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   measurements by providing a list of PennyLane
   `measurements <https://docs.pennylane.ai/en/stable/introduction/measurements.html>`_ themselves.
   [(#405)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/405)
+  [(#466)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/466)
 
 * Added the support for converting conditional operations based on mid-circuit measurements and
   two of the ``ControlFlowOp`` operations - ``IfElseOp`` and ``SwitchCaseOp`` when converting

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -15,7 +15,7 @@ r"""
 This module contains functions for converting Qiskit QuantumCircuit objects
 into PennyLane circuit templates.
 """
-from typing import Dict, Any, Sequence, Union
+from typing import Dict, Any, Iterable, Sequence, Union
 import warnings
 from functools import partial, reduce
 
@@ -553,7 +553,7 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
 
         # Use the user-provided measurements
         if measurements:
-            if qml.queuing.QueuingManager.active_context():
+            if isinstance(measurements, Iterable) and qml.queuing.QueuingManager.active_context():
                 return [qml.apply(meas) for meas in measurements]
             return measurements
 

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -349,12 +349,12 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
 
     Args:
         quantum_circuit (qiskit.QuantumCircuit): the QuantumCircuit to be converted
-        measurements (list[pennylane.measurements.MeasurementProcess]): the list of PennyLane
-            `measurements <https://docs.pennylane.ai/en/stable/introduction/measurements.html>`_
-            that overrides the terminal measurements that may be present in the input circuit.
+        measurements (None | pennylane.measurements.MeasurementProcess | Iterable[pennylane.measurements.MeasurementProcess]):
+            the PennyLane `measurements <https://docs.pennylane.ai/en/stable/introduction/measurements.html>`_
+            that override the terminal measurements that may be present in the input circuit.
 
     Returns:
-        function: the resulting PennyLane template
+        function: The resulting PennyLane template.
     """
 
     # pylint:disable=too-many-branches, fixme, protected-access

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -349,7 +349,7 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
 
     Args:
         quantum_circuit (qiskit.QuantumCircuit): the QuantumCircuit to be converted
-        measurements (None | pennylane.measurements.MeasurementProcess | Iterable[pennylane.measurements.MeasurementProcess]):
+        measurements (None | pennylane.measurements.MeasurementProcess | list[pennylane.measurements.MeasurementProcess]):
             the PennyLane `measurements <https://docs.pennylane.ai/en/stable/introduction/measurements.html>`_
             that override the terminal measurements that may be present in the input circuit.
 

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -553,9 +553,13 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
 
         # Use the user-provided measurements
         if measurements:
-            if isinstance(measurements, Iterable) and qml.queuing.QueuingManager.active_context():
+            if not qml.queuing.QueuingManager.active_context():
+                return measurements
+
+            if isinstance(measurements, Iterable):
                 return [qml.apply(meas) for meas in measurements]
-            return measurements
+
+            return qml.apply(measurements)
 
         return tuple(mid_circ_meas + list(map(qml.measure, terminal_meas))) or None
 

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -351,7 +351,7 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
         quantum_circuit (qiskit.QuantumCircuit): the QuantumCircuit to be converted
         measurements (None | pennylane.measurements.MeasurementProcess | list[pennylane.measurements.MeasurementProcess]):
             the PennyLane `measurements <https://docs.pennylane.ai/en/stable/introduction/measurements.html>`_
-            that override the terminal measurements that may be present in the input circuit.
+            that override the terminal measurements that may be present in the input circuit
 
     Returns:
         function: The resulting PennyLane template.

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1472,6 +1472,7 @@ class TestConverterIntegration:
         """Tests loading a converted template in a QNode with a single measurement."""
         qc = QuantumCircuit(1)
         qc.h(0)
+        qc.measure_all()
 
         measurement = qml.expval(qml.PauliZ(0))
         quantum_circuit = load(qc, measurements=measurement)
@@ -1483,7 +1484,7 @@ class TestConverterIntegration:
         @qml.qnode(qubit_device_single_wire)
         def circuit_native_pennylane():
             qml.Hadamard(0)
-            return measurement
+            return qml.expval(qml.PauliZ(0))
 
         assert circuit_loaded_qiskit_circuit() == circuit_native_pennylane()
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1468,8 +1468,27 @@ class TestConverterIntegration:
 
         assert np.allclose(jac, jac_expected)
 
-    def test_meas_circuit_in_qnode(self, qubit_device_2_wires):
-        """Tests loading a converted template in a QNode with measurements."""
+    def test_quantum_circuit_with_single_measurement(self, qubit_device_single_wire):
+        """Tests loading a converted template in a QNode with a single measurement."""
+        qc = QuantumCircuit(1)
+        qc.h(0)
+
+        measurement = qml.expval(qml.PauliZ(0))
+        quantum_circuit = load(qc, measurements=measurement)
+
+        @qml.qnode(qubit_device_single_wire)
+        def circuit_loaded_qiskit_circuit():
+            return quantum_circuit()
+
+        @qml.qnode(qubit_device_single_wire)
+        def circuit_native_pennylane():
+            qml.Hadamard(0)
+            return measurement
+
+        assert circuit_loaded_qiskit_circuit() == circuit_native_pennylane()
+
+    def test_quantum_circuit_with_multiple_measurements(self, qubit_device_2_wires):
+        """Tests loading a converted template in a QNode with multiple measurements."""
 
         angle = 0.543
 


### PR DESCRIPTION
This PR makes it possible to load a Qiskit circuit from PennyLane using
```python
qml.from_qiskit(qc, measurements=qml.expval(qml.PauliZ(0)))
```
instead of
```python
qml.from_qiskit(qc, measurements=[qml.expval(qml.PauliZ(0))])
```