### PR TITLE
Add condition for treating all measurements as equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   `measurements <https://docs.pennylane.ai/en/stable/introduction/measurements.html>`_ themselves.
   [(#405)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/405)
   [(#466)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/466)
+  [(#467)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/467)
 
 * Added the support for converting conditional operations based on mid-circuit measurements and
   two of the `ControlFlowOp` operations - `IfElseOp` and `SwitchCaseOp` when converting

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -483,28 +483,32 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
             elif isinstance(instruction, Measure):
                 # Store the current operation wires and registers
                 op_wires, op_cregs = set(operation_wires), set(cargs)
-                # Look-ahead for more gate(s) on its wire(s)
-                meas_terminal = True
-                for next_op, next_qargs, next_cargs in qc.data[idx + 1 :]:
-                    # Check if the subsequent conditional is measurement needing
-                    if isinstance(next_op, ControlFlowOp):
-                        if set(next_cargs) & op_cregs:
-                            meas_terminal = False
-                            break
-                    elif next_op.condition:  # For legacy c_if
-                        next_op_reg = next_op.condition[0]
-                        if isinstance(next_op_reg, Clbit):
-                            next_op_reg = [next_op_reg]
-                        if set(next_op_reg) & op_cregs:
-                            meas_terminal = False
-                            break
-                    # Check if the subsequent next_op is measurement interfering
-                    if not isinstance(next_op, (Barrier, GlobalPhaseGate)):
-                        next_op_wires = set(wire_map[hash(qubit)] for qubit in next_qargs)
-                        # Check if there's any overlapping wires
-                        if next_op_wires & op_wires:
-                            meas_terminal = False
-                            break
+                # If final measurements are given then discriminate
+                # between the types of measurement encountered.
+                meas_terminal = False
+                if measurements:
+                    # Look-ahead for more gate(s) on its wire(s)
+                    meas_terminal = True
+                    for next_op, next_qargs, next_cargs in qc.data[idx + 1 :]:
+                        # Check if the subsequent conditional is measurement needing
+                        if isinstance(next_op, ControlFlowOp):
+                            if set(next_cargs) & op_cregs:
+                                meas_terminal = False
+                                break
+                        elif next_op.condition:  # For legacy c_if
+                            next_op_reg = next_op.condition[0]
+                            if isinstance(next_op_reg, Clbit):
+                                next_op_reg = [next_op_reg]
+                            if set(next_op_reg) & op_cregs:
+                                meas_terminal = False
+                                break
+                        # Check if the subsequent next_op is measurement interfering
+                        if not isinstance(next_op, (Barrier, GlobalPhaseGate)):
+                            next_op_wires = set(wire_map[hash(qubit)] for qubit in next_qargs)
+                            # Check if there's any overlapping wires
+                            if next_op_wires & op_wires:
+                                meas_terminal = False
+                                break
 
                 # Allows for adding terminal measurements
                 if meas_terminal:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1836,12 +1836,12 @@ class TestControlOpIntegration:
         with qc.if_test((1, 1)):
             qc.x(2)
 
-        m0, m1 = qml.from_qiskit(qc)()
+        m0, m1 = load(qc)()
         w0, w1 = qml.wires.Wires([0]), qml.wires.Wires([1])
         assert isinstance(m0, qml.measurements.MeasurementValue) and m0.wires == w0
         assert isinstance(m1, qml.measurements.MeasurementValue) and m1.wires == w1
 
-        m2 = qml.from_qiskit(qc, measurements=qml.expval(qml.PauliZ(2)))()
+        m2 = load(qc, measurements=qml.expval(qml.PauliZ(2)))()
         w2 = qml.wires.Wires([2])
         assert isinstance(m2, qml.measurements.ExpectationMP) and m2.wires == w2
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1791,7 +1791,7 @@ class TestControlOpIntegration:
         qc.measure(0, 0)
         qc.measure(1, 1)
 
-        with qc.if_test((0, 1)):
+        with qc.if_test((1, 1)):
             qc.x(2)
 
         dev = qml.device("default.qubit", wires=3)
@@ -1809,8 +1809,8 @@ class TestControlOpIntegration:
             qml.CNOT([0, 1])
             qml.Hadamard([0])
             m0 = qml.measure(0)
-            qml.cond(m0 == 1, qml.PauliX)(wires=[2])
             m1 = qml.measure(1)
+            qml.cond(m1 == 1, qml.PauliX)(wires=[2])
             return qml.expval(qml.PauliZ(0))
 
         assert qk_circuit() == pl_circuit()
@@ -1822,6 +1822,28 @@ class TestControlOpIntegration:
             )
             for op1, op2 in zip(qk_circuit.tape.operations, pl_circuit.tape.operations)
         )
+
+    def test_measurement_are_not_discriminated(self):
+        """Test the all measurements are considered mid-circuit measurements when no terminal measurements are given"""
+
+        qc = QuantumCircuit(3, 2)
+
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.measure(0, 0)
+        qc.measure(1, 1)
+
+        with qc.if_test((1, 1)):
+            qc.x(2)
+
+        m0, m1 = qml.from_qiskit(qc)()
+        w0, w1 = qml.wires.Wires([0]), qml.wires.Wires([1])
+        assert isinstance(m0, qml.measurements.MeasurementValue) and m0.wires == w0
+        assert isinstance(m1, qml.measurements.MeasurementValue) and m1.wires == w1
+
+        m2 = qml.from_qiskit(qc, measurements=qml.expval(qml.PauliZ(2)))()
+        w2 = qml.wires.Wires([2])
+        assert isinstance(m2, qml.measurements.ExpectationMP) and m2.wires == w2
 
 
 class TestPassingParameters:


### PR DESCRIPTION
Allows for treating all measurements in the circuit as equal and returning them in order to the user when `measurements` are not specified.