### PR TITLE
Pin qiskit-ibm-runtime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.rst", "r") as fh:
 requirements = [
     "qiskit>=0.32",
     "qiskit-aer",
-    "qiskit-ibm-runtime",
+    "qiskit-ibm-runtime<0.21",
     "qiskit-ibm-provider",
     "pennylane>=0.30",
     "numpy",


### PR DESCRIPTION
Qiskit just released a new version of `qiskit-ibm-runtim` that requires `qiskit>1.0`, and this is causing [test failures](https://github.com/PennyLaneAI/plugin-test-matrix/actions/runs/8180658157/job/22397046352) because it tries to update to Qiskit 1.0 after we've installed <1.0 in the same environment.

This should fix it. This change has been noted in shortcut (#57197), where we are tracking everything that needs to be reversed once we've completed work to support Qiskit 1.0 with the plugin.