### PR TITLE
Update IBMQ tests to (hopefully) respect the pin

### DIFF
--- a/.github/workflows/ibmq_tests.yml
+++ b/.github/workflows/ibmq_tests.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Install Plugin
         run: |
-          python setup.py bdist_wheel
-          pip install dist/PennyLane*.whl
+          pip install git+https://github.com/PennyLaneAI/pennylane-qiskit.git
+          pip freeze
 
       - name: Run tests
         # Only run IBMQ and Runtime tests (skipped otherwise)

--- a/.github/workflows/ibmq_tests.yml
+++ b/.github/workflows/ibmq_tests.yml
@@ -33,7 +33,8 @@ jobs:
 
       - name: Install Plugin
         run: |
-          pip install git+https://github.com/PennyLaneAI/pennylane-qiskit.git
+          pip install git+https://github.com/PennyLaneAI/pennylane-qiskit.git@${{ env.PLUGIN_BRANCH }}
+
           pip freeze
 
       - name: Run tests


### PR DESCRIPTION
The IBMQ tests are still running with `qiskit-ibm-runtime=0.21.1` after pinning in setup in #486. Trying to fix.