### PR TITLE
Change qml.load to qml.from_qiskit

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -228,7 +228,7 @@ class TestLoadIntegration:
         qc = qiskit.QuantumCircuit(2)
         qc.rx(theta, 0)
 
-        my_template = qml.load(qc, format="qiskit")
+        my_template = qml.from_qiskit(qc)
 
         dev = qml.device("default.qubit", wires=2)
 


### PR DESCRIPTION
`qml.load` is being deprecated in PennyLane. Updating the test case to use `qml.from_qiskit` instead.