### PR TITLE
Compatibility with 1.0 for devices

### DIFF
--- a/.github/workflows/ibmq_tests.yml
+++ b/.github/workflows/ibmq_tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-ci.txt
+          pip install -r requirements-ci-legacy.txt
           pip install wheel pytest pytest-cov pytest-mock flaky --upgrade
           pip freeze
 

--- a/.github/workflows/ibmq_tests_1.yml
+++ b/.github/workflows/ibmq_tests_1.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-ci0.txt
+          pip install -r requirements-ci.txt
           pip install wheel pytest pytest-cov pytest-mock flaky --upgrade
           pip freeze
 

--- a/.github/workflows/ibmq_tests_1.yml
+++ b/.github/workflows/ibmq_tests_1.yml
@@ -1,0 +1,44 @@
+name: IBMQ integration tests with Qiskit 1.0
+on:
+  schedule:
+    - cron: '1 0 * * 0,4' # At 01:00 on Sunday and Thursday.
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-ci0.txt
+          pip install wheel pytest pytest-cov pytest-mock flaky --upgrade
+          pip freeze
+
+      - name: Install Plugin
+        run: |
+          pip install git+https://github.com/PennyLaneAI/pennylane-qiskit.git@${{ github.ref }}
+          pip freeze
+
+      - name: Run tests
+        # Only run IBMQ and Runtime tests (skipped otherwise)
+        run: python -m pytest tests -k 'test_ibmq.py or test_runtime.py' --cov=pennylane_qiskit --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
+        env:
+          IBMQX_TOKEN: ${{ secrets.IBMQX_TOKEN_TEST }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,11 +31,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-ci.txt
           pip install wheel pytest pytest-cov pytest-mock flaky --upgrade
+          pip freeze
 
       - name: Install Plugin
         run: |
-          python setup.py bdist_wheel
-          pip install dist/PennyLane*.whl
+          pip install git+https://github.com/PennyLaneAI/pennylane-qiskit.git@${{ github.ref }}
+          pip freeze
 
       - name: Run tests
         # Skip IBMQ and Runtime tests as they depend on IBMQ's availability and

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-ci.txt
+          pip install -r requirements-ci-legacy.txt
           pip install wheel pytest pytest-cov pytest-mock flaky --upgrade
           pip freeze
 
@@ -69,7 +69,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-ci.txt
+          pip install -r requirements-ci-legacy.txt
           pip install wheel pytest pytest-cov pytest-mock pytest-benchmark flaky --upgrade
 
       - name: Install Plugin

--- a/.github/workflows/tests_qiskit_1.yml
+++ b/.github/workflows/tests_qiskit_1.yml
@@ -45,3 +45,42 @@ jobs:
       - name: Run IBMQ tests
         # seperated because they noramlly only run twice a week, but not clear that's necessary anymore
         run: python -m pytest tests -k 'test_ibmq.py or test_runtime.py' --cov=pennylane_qiskit --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
+
+  integration-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-ci0.txt
+          pip install wheel pytest pytest-cov pytest-mock pytest-benchmark flaky --upgrade
+
+      - name: Install Plugin
+        run: |
+          python setup.py bdist_wheel
+          pip install dist/PennyLane*.whl
+
+      - name: Run tests
+        run: |
+          pl-device-test --device=qiskit.basicsim --tb=short --skip-ops --shots=20000 --device-kwargs backend=qasm_simulator
+          pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=20000 --device-kwargs backend=qasm_simulator
+          pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=statevector_simulator
+          pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=unitary_simulator
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml

--- a/.github/workflows/tests_qiskit_1.yml
+++ b/.github/workflows/tests_qiskit_1.yml
@@ -31,11 +31,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-ci0.txt
           pip install wheel pytest pytest-cov pytest-mock flaky --upgrade
+          pip freeze
 
       - name: Install Plugin
         run: |
-          python setup.py bdist_wheel
-          pip install dist/PennyLane*.whl
+          pip install git+https://github.com/PennyLaneAI/pennylane-qiskit.git@${{ github.ref }}
+          pip freeze
 
       - name: Run Qiskit converter tests
         # Test conversion to PennyLane with Qiskit 1.0.0

--- a/.github/workflows/tests_qiskit_1.yml
+++ b/.github/workflows/tests_qiskit_1.yml
@@ -43,8 +43,9 @@ jobs:
         run: python -m pytest tests -k 'not test_ibmq.py and not test_runtime.py' --cov=pennylane_qiskit --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.codecov_token }}
           file: ./coverage.xml
 
   integration-tests:

--- a/.github/workflows/tests_qiskit_1.yml
+++ b/.github/workflows/tests_qiskit_1.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-ci0.txt
+          pip install -r requirements-ci.txt
           pip install wheel pytest pytest-cov pytest-mock flaky --upgrade
           pip freeze
 
@@ -66,7 +66,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-ci0.txt
+          pip install -r requirements-ci.txt
           pip install wheel pytest pytest-cov pytest-mock pytest-benchmark flaky --upgrade
 
       - name: Install Plugin

--- a/.github/workflows/tests_qiskit_1.yml
+++ b/.github/workflows/tests_qiskit_1.yml
@@ -82,6 +82,7 @@ jobs:
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=unitary_simulator
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.codecov_token }}
           file: ./coverage.xml

--- a/.github/workflows/tests_qiskit_1.yml
+++ b/.github/workflows/tests_qiskit_1.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pl-device-test --device=qiskit.basicsim --tb=short --skip-ops --shots=20000 --device-kwargs backend=qasm_simulator
+          pl-device-test --device=qiskit.basicsim --tb=short --skip-ops --shots=20000 --device-kwargs backend=basic_simulator
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=20000 --device-kwargs backend=qasm_simulator
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=statevector_simulator
           pl-device-test --device=qiskit.aer --tb=short --skip-ops --shots=None --device-kwargs backend=unitary_simulator

--- a/.github/workflows/tests_qiskit_1.yml
+++ b/.github/workflows/tests_qiskit_1.yml
@@ -38,10 +38,10 @@ jobs:
           pip install git+https://github.com/PennyLaneAI/pennylane-qiskit.git@${{ github.ref }}
           pip freeze
 
-      - name: Run Qiskit converter tests
-        # Test conversion to PennyLane with Qiskit 1.0.0
-        run: python -m pytest tests/test_converter.py
+      - name: Run standard Qiskit plugin tests
+        # Run the standard tests with the most recent version of Qiskit
+        run: python -m pytest tests -k 'not test_ibmq.py and not test_runtime.py' --cov=pennylane_qiskit --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
 
-      - name: Run temporary tests
-        # tests that test intermediate functionality, will be removed when everything is fully compatible with 1.0
-        run: python -m pytest tests/test_new_qiskit_temp.py
+      - name: Run IBMQ tests
+        # seperated because they noramlly only run twice a week, but not clear that's necessary anymore
+        run: python -m pytest tests -k 'test_ibmq.py or test_runtime.py' --cov=pennylane_qiskit --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native

--- a/.github/workflows/tests_qiskit_1.yml
+++ b/.github/workflows/tests_qiskit_1.yml
@@ -42,9 +42,10 @@ jobs:
         # Run the standard tests with the most recent version of Qiskit
         run: python -m pytest tests -k 'not test_ibmq.py and not test_runtime.py' --cov=pennylane_qiskit --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
 
-      - name: Run IBMQ tests
-        # seperated because they noramlly only run twice a week, but not clear that's necessary anymore
-        run: python -m pytest tests -k 'test_ibmq.py or test_runtime.py' --cov=pennylane_qiskit --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build and install Plugin
         run: |
           python -m pip install --upgrade pip wheel
-          pip install 'qiskit<0.46'
+          pip install qiskit
           python setup.py bdist_wheel
           pip install dist/PennyLane*.whl
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### New features since last release
 
+* Support is added for using the plugin devices with Qiskit 1.0. As the backend provider ``qiskit.BasicAer`` 
+  is no longer supported by Qiskit in 1.0, this added support does not extend to the ``"qiskit.aer"`` device. 
+  Instead, a ``"qiskit.basicsim"`` device is added, with the new Qiskit implementation of a Python simulator 
+  device, ``BasicSimulator``, as the backend.
+  [(#493)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/493)
+
 ### Improvements 🛠
 
 ### Breaking changes 💔
@@ -15,6 +21,7 @@
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+Lillian M. A. Frederiksen
 
 ---
 # Release 0.35.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 
 ### Improvements 🛠
 
+* Following updates to allow device compatibility with Qiskit 1.0, the version of `qiskit-ibm-runtime` is 
+  no longer capped.
+  [(#508)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/508)
+
+* The test suite now runs with the most recent `qiskit` and `qiskit-ibm-runtime`, and well as with 
+  `'qiskit==0.45'` and `qiskit-ibm-runtime<0.21` to monitor backward-compatibility.
+  [(#508)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/508)
+
 ### Breaking changes 💔
 
 ### Deprecations 👋

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ in the source folder.
     `new IBMProvider <https://qiskit.org/ecosystem/ibm-provider/stubs/qiskit_ibm_provider.IBMProvider.html>`_
 
     If this is the case, running ``make test`` also executes tests on the ``ibmq`` device.
-    By default tests on the ``ibmq`` device run with ``ibmq_qasm_simulator`` backend. At
+    By default, tests on the ``ibmq`` device run with ``ibmq_qasm_simulator`` backend. At
     the time of writing this means that the test are "free".
     Please verify that this is also the case for your account.
 

--- a/README.rst
+++ b/README.rst
@@ -58,14 +58,7 @@ Installation of this plugin, as well as all dependencies, can be done using ``pi
 
 .. code-block:: bash
 
-    pip install "qiskit<0.46"
     pip install pennylane-qiskit
-
-If you prefer to use Qiskit 1.0, you can omit the first line above and instead consult the
-`Qiskit installation guide <https://docs.quantum.ibm.com/start/install>`__, which includes
-details on how to migrate to 1.0 if you already have Qiskit installed.
-Note that only conversion to PennyLane is supported with Qiskit 1.0; support
-for devices with 1.0 be available in a later release of the plugin.
 
 To test that the PennyLane-Qiskit plugin is working correctly you can run
 
@@ -73,8 +66,7 @@ To test that the PennyLane-Qiskit plugin is working correctly you can run
 
     make test
 
-in the source folder. Tests restricted to a specific provider can be run by executing
-``make test-basicaer``, ``make test-aer``, and ``make test-ibmq``.
+in the source folder.
 
 .. note::
 
@@ -88,9 +80,8 @@ in the source folder. Tests restricted to a specific provider can be run by exec
     `new IBMProvider <https://qiskit.org/ecosystem/ibm-provider/stubs/qiskit_ibm_provider.IBMProvider.html>`_
 
     If this is the case, running ``make test`` also executes tests on the ``ibmq`` device.
-    By default tests on the ``ibmq`` device run with ``ibmq_qasm_simulator`` backend
-    and those done by the ``basicaer`` and ``aer`` device are run with the ``qasm_simulator``
-    backend. At the time of writing this means that the test are "free".
+    By default tests on the ``ibmq`` device run with ``ibmq_qasm_simulator`` backend. At
+    the time of writing this means that the test are "free".
     Please verify that this is also the case for your account.
 
 .. installation-end-inclusion-marker-do-not-remove

--- a/doc/devices/aer.rst
+++ b/doc/devices/aer.rst
@@ -1,4 +1,4 @@
-.. _aer_device_page:
+.. _aer device page:
 
 The Aer device
 ==============

--- a/doc/devices/aer.rst
+++ b/doc/devices/aer.rst
@@ -1,3 +1,5 @@
+.. _aer_device_page:
+
 The Aer device
 ==============
 The ``qiskit.aer`` device provided by the PennyLane-Qiskit plugin allows you to use PennyLane

--- a/doc/devices/basicaer.rst
+++ b/doc/devices/basicaer.rst
@@ -5,7 +5,7 @@ The BasicAer device
 
     Qiskit discontinued their ``BasicAer`` device in the 1.0 release, so this device
     is only available for lower versions of Qiskit. For a simple Python simulator
-    compatible with Qiskit 1.0, use the ``'qiskit.basicsim'`` device instead.
+    compatible with Qiskit 1.0, use the `'qiskit.basicsim' device <https://docs.pennylane.ai/projects/qiskit/en/latest/devices/basicsim.html>`_ instead.
 
 While the ``'qiskit.aer'`` device is the standard go-to simulator that is provided along
 the Qiskit main package installation, there exists a natively included python simulator

--- a/doc/devices/basicaer.rst
+++ b/doc/devices/basicaer.rst
@@ -2,6 +2,7 @@ The BasicAer device
 ===================
 
 ..note::
+
     Qiskit discontinued their BasicAer device in the 1.0 release, so this device
     is only available for lower versions of Qiskit. For a simple Python simulator
     compatible with Qiskit 1.0, use the ``'qiskit.basicsim'`` device instead.

--- a/doc/devices/basicaer.rst
+++ b/doc/devices/basicaer.rst
@@ -5,7 +5,7 @@ The BasicAer device
 
     Qiskit discontinued their ``BasicAer`` device in the 1.0 release, so this device
     is only available for lower versions of Qiskit. For a simple Python simulator
-    compatible with Qiskit 1.0, use the `'qiskit.basicsim' device <https://docs.pennylane.ai/projects/qiskit/en/latest/devices/basicsim.html>`_ instead.
+    compatible with Qiskit 1.0, use the :ref:`BasicSim device <basicsim device page>` instead.
 
 While the ``'qiskit.aer'`` device is the standard go-to simulator that is provided along
 the Qiskit main package installation, there exists a natively included python simulator

--- a/doc/devices/basicaer.rst
+++ b/doc/devices/basicaer.rst
@@ -1,9 +1,9 @@
 The BasicAer device
 ===================
 
-..note::
+.. note::
 
-    Qiskit discontinued their BasicAer device in the 1.0 release, so this device
+    Qiskit discontinued their ``BasicAer`` device in the 1.0 release, so this device
     is only available for lower versions of Qiskit. For a simple Python simulator
     compatible with Qiskit 1.0, use the ``'qiskit.basicsim'`` device instead.
 

--- a/doc/devices/basicsim.rst
+++ b/doc/devices/basicsim.rst
@@ -17,6 +17,6 @@ This device uses the Qiskit ``BasicSimulator`` backend from the
 
     The `Qiskit Aer <https://qiskit.github.io/qiskit-aer/>`_ device
     provides a fast simulator that is also capable of simulating
-    noise. It is available :ref:`here <TODO>` but must be
+    noise. It is available :ref:`basicsim` but must be
     installed separately with ``pip install qiskit-aer``.
     

--- a/doc/devices/basicsim.rst
+++ b/doc/devices/basicsim.rst
@@ -1,10 +1,9 @@
 The BasicSim device
 ===================
 
-While the ``'qiskit.aer'`` device is the standard go-to simulator that is provided along
-the Qiskit main package installation, there exists a natively included python simulator
-that is slower but will work usually without the need to install other dependencies
-(C++, BLAS, and so on). This simulator can be used through the device ``'qiskit.basicsim'``:
+Qiskit comes packed with a
+`basic pure-Python simulator <https://docs.quantum.ibm.com/api/qiskit/qiskit.providers.basic_provider.BasicSimulator>`_
+that can be accessed in this plugin through:
 
 .. code-block:: python
 

--- a/doc/devices/basicsim.rst
+++ b/doc/devices/basicsim.rst
@@ -17,6 +17,6 @@ This device uses the Qiskit ``BasicSimulator`` backend from the
 
     The `Qiskit Aer <https://qiskit.github.io/qiskit-aer/>`_ device
     provides a fast simulator that is also capable of simulating
-    noise. It is available through the :ref:`Aer device <_aer_device_page>` but must be
+    noise. It is available through the :ref:`Aer device <aer device page>` but must be
     installed separately with ``pip install qiskit-aer``.
     

--- a/doc/devices/basicsim.rst
+++ b/doc/devices/basicsim.rst
@@ -1,3 +1,5 @@
+.. _basicsim device page:
+
 The BasicSim device
 ===================
 
@@ -17,6 +19,6 @@ This device uses the Qiskit ``BasicSimulator`` backend from the
 
     The `Qiskit Aer <https://qiskit.github.io/qiskit-aer/>`_ device
     provides a fast simulator that is also capable of simulating
-    noise. It is available through the :ref:`Aer device <aer device page>` but must be
+    noise. It is available as :ref:`"qiskit.aer" <aer device page>`, but the backend must be
     installed separately with ``pip install qiskit-aer``.
     

--- a/doc/devices/basicsim.rst
+++ b/doc/devices/basicsim.rst
@@ -11,4 +11,5 @@ that is slower but will work usually without the need to install other dependenc
     import pennylane as qml
     dev = qml.device('qiskit.basicsim', wires=2)
 
-This device uses the Qiskit ``BasicSimulator`` backend.
+This device uses the Qiskit ``BasicSimulator`` backend from the
+`basic_provider <https://docs.quantum.ibm.com/api/qiskit/providers_basic_provider>`_ module in Qiskit.

--- a/doc/devices/basicsim.rst
+++ b/doc/devices/basicsim.rst
@@ -12,3 +12,11 @@ that can be accessed in this plugin through:
 
 This device uses the Qiskit ``BasicSimulator`` backend from the
 `basic_provider <https://docs.quantum.ibm.com/api/qiskit/providers_basic_provider>`_ module in Qiskit.
+
+.. note::
+
+    The `Qiskit Aer <https://qiskit.github.io/qiskit-aer/>`_ device
+    provides a fast simulator that is also capable of simulating
+    noise. It is available :ref:`here <TODO>` but must be
+    installed separately with ``pip install qiskit-aer``.
+    

--- a/doc/devices/basicsim.rst
+++ b/doc/devices/basicsim.rst
@@ -1,20 +1,15 @@
-The BasicAer device
+The BasicSim device
 ===================
-
-..note::
-    Qiskit discontinued their BasicAer device in the 1.0 release, so this device
-    is only available for lower versions of Qiskit. For a simple Python simulator
-    compatible with Qiskit 1.0, use the ``'qiskit.basicsim'`` device instead.
 
 While the ``'qiskit.aer'`` device is the standard go-to simulator that is provided along
 the Qiskit main package installation, there exists a natively included python simulator
 that is slower but will work usually without the need to install other dependencies
-(C++, BLAS, and so on). This simulator can be used through the device ``'qiskit.basicaer'``:
+(C++, BLAS, and so on). This simulator can be used through the device ``'qiskit.basicsim'``:
 
 .. code-block:: python
 
     import pennylane as qml
-    dev = qml.device('qiskit.basicaer', wires=2)
+    dev = qml.device('qiskit.basicsim', wires=2)
 
 As with the ``'qiskit.aer'`` device, there are different backends available, which you can find
 by calling

--- a/doc/devices/basicsim.rst
+++ b/doc/devices/basicsim.rst
@@ -17,6 +17,6 @@ This device uses the Qiskit ``BasicSimulator`` backend from the
 
     The `Qiskit Aer <https://qiskit.github.io/qiskit-aer/>`_ device
     provides a fast simulator that is also capable of simulating
-    noise. It is available :ref:`basicsim` but must be
+    noise. It is available through the :ref:`Aer device <_aer_device_page>` but must be
     installed separately with ``pip install qiskit-aer``.
     

--- a/doc/devices/basicsim.rst
+++ b/doc/devices/basicsim.rst
@@ -11,16 +11,4 @@ that is slower but will work usually without the need to install other dependenc
     import pennylane as qml
     dev = qml.device('qiskit.basicsim', wires=2)
 
-As with the ``'qiskit.aer'`` device, there are different backends available, which you can find
-by calling
-
-.. code-block:: python
-
-    dev.capabilities()['backend']
-
-.. note::
-
-    Currently, PennyLane does not support the ``'pulse_simulator'`` backend.
-
-The backends are used in the same manner as specified for the ``'qiskit.aer'`` device.
-The ``'qiskit.basicaer'`` device, however, does not support the simulation of noise models.
+This device uses the Qiskit ``BasicSimulator`` backend.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,7 @@ can be accessed straightaway in PennyLane, without the need to import new packag
 Devices
 ~~~~~~~
 
-Currently, there are three different devices available:
+Currently, there are seven different devices available:
 
 .. title-card::
     :name: 'qiskit.aer'
@@ -25,6 +25,11 @@ Currently, there are three different devices available:
     :name: 'qiskit.basicaer'
     :description: A simplified version of the Aer device, which requires fewer dependencies.
     :link: devices/basicaer.html
+
+.. title-card::
+    :name: 'qiskit.basicsim'
+    :description: A simple local Python simulator running the Qiskit ``BasicSimulator``.
+    :link: devices/basicsim.html
 
 .. title-card::
     :name: 'qiskit.ibmq'
@@ -133,6 +138,7 @@ hardware access.
 
    devices/aer
    devices/basicaer
+   devices/basicsim
    devices/ibmq
    devices/runtime
    devices/remote

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,22 +33,22 @@ The following devices are available:
 
 .. title-card::
     :name: 'qiskit.ibmq.circuit_runner'
-    :description: Allows integration with qiskit's circuit runner runtime program.
+    :description: Allows integration with Qiskit's circuit runner runtime program.
     :link: devices/runtime.html
 
 .. title-card::
     :name: 'qiskit.ibmq.sampler'
-    :description: Allows integration with qiskit's sampler runtime program.
+    :description: Allows integration with Qiskit's sampler runtime program.
     :link: devices/runtime.html
 
 .. title-card::
     :name: 'qiskit.remote'
-    :description: Allows integration with any qiskit backend.
+    :description: Allows integration with any Qiskit backend.
     :link: devices/remote.html
 
 .. title-card::
     :name: 'qiskit.ibmq'
-    :description: Allows integration with qiskit's hardware backends, and hardware-specific simulators.
+    :description: Allows integration with Qiskit's hardware backends, and hardware-specific simulators.
     :link: devices/ibmq.html
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,7 @@ can be accessed straightaway in PennyLane, without the need to import new packag
 Devices
 ~~~~~~~
 
-Currently, there are seven different devices available:
+The following devices are available:
 
 .. title-card::
     :name: 'qiskit.aer'

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,11 +32,6 @@ The following devices are available:
     :link: devices/basicsim.html
 
 .. title-card::
-    :name: 'qiskit.ibmq'
-    :description: Allows integration with qiskit's hardware backends, and hardware-specific simulators.
-    :link: devices/ibmq.html
-
-.. title-card::
     :name: 'qiskit.ibmq.circuit_runner'
     :description: Allows integration with qiskit's circuit runner runtime program.
     :link: devices/runtime.html
@@ -50,6 +45,12 @@ The following devices are available:
     :name: 'qiskit.remote'
     :description: Allows integration with any qiskit backend.
     :link: devices/remote.html
+
+.. title-card::
+    :name: 'qiskit.ibmq'
+    :description: Allows integration with qiskit's hardware backends, and hardware-specific simulators.
+    :link: devices/ibmq.html
+
 
 .. raw:: html
 

--- a/pennylane_qiskit/__init__.py
+++ b/pennylane_qiskit/__init__.py
@@ -15,7 +15,7 @@
 
 from ._version import __version__
 from .aer import AerDevice
-from .basic_aer import BasicAerDevice
+from .basic_aer import BasicAerDevice, BasicSimulatorDevice
 from .ibmq import IBMQDevice
 from .remote import RemoteDevice
 from .converter import load, load_pauli_op, load_qasm, load_qasm_from_file

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -22,6 +22,9 @@ from semantic_version import Version
 
 from .qiskit_device import QiskitDevice
 
+if Version(qiskit.__version__) >= Version("1.0.0"):
+    from qiskit.providers.basic_provider import BasicProvider
+
 
 class BasicAerDevice(QiskitDevice):
     """A PennyLane device for the native Python Qiskit simulator BasicAer.
@@ -108,7 +111,5 @@ class BasicSimulatorDevice(QiskitDevice):
                 f"use the 'qiskit.basicaer' device instead. Alternatively, upgrade Qiskit "
                 f"to use the 'qiskit.basicsim' device."
             )
-
-        from qiskit.providers.basic_provider import BasicProvider
 
         super().__init__(wires, provider=BasicProvider(), backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -57,7 +57,7 @@ class BasicAerDevice(QiskitDevice):
 
     def __init__(self, wires, shots=1024, backend="qasm_simulator", **kwargs):
 
-        max_ver = Version("0.46")
+        max_ver = Version("0.46", partial=True)
 
         if Version(qiskit.__version__) > max_ver:
             raise RuntimeError(

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -17,6 +17,7 @@ evaluation and differentiation of Qiskit Terra's BasicAer simulator
 using PennyLane.
 """
 import qiskit
+import warnings
 
 from semantic_version import Version
 
@@ -95,6 +96,12 @@ class BasicSimulatorDevice(QiskitDevice):
 
     short_name = "qiskit.basicsim"
 
+    analytic_warning_message = (
+        "The plugin does not currently support analytic calculation of expectations, variances "
+        "and probabilities with the BasicProvider backend {}. Such statistics obtained from this "
+        "device are estimates based on samples."
+    )
+
     def __init__(self, wires, shots=1024, backend="basic_simulator", **kwargs):
 
         min_version = Version("1.0.0")
@@ -106,17 +113,5 @@ class BasicSimulatorDevice(QiskitDevice):
                 f"use the 'qiskit.basicaer' device instead. Alternatively, upgrade Qiskit "
                 f"(see https://docs.quantum.ibm.com/start/install) to use the 'qiskit.basicsim' device."
             )
-
-        analytic_warning_message = (
-            "The plugin does not currently support analytic calculation of expectations, variances "
-            "and probabilities with the BasicProvider backend(s). Such statistics obtained from this "
-            "device are estimates based on samples."
-        )
-
-        # Raise a warning if no shots were specified
-        if not shots:
-            warnings.warn(self.analytic_warning_message, UserWarning)
-            shots = 1024
-
 
         super().__init__(wires, provider=BasicProvider(), backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -72,13 +72,11 @@ class BasicAerDevice(QiskitDevice):
 
 
 class BasicSimulatorDevice(QiskitDevice):
-    """A PennyLane device for the native Python Qiskit simulator from BasicProvider.
+    """A PennyLane device for the native Python Qiskit simulator.
 
-    For more information on the BasicSimulator backend options and transpile options, please visit the
+    For more information on the ``BasicSimulator`` backend options and transpile options, please visit the
     `BasicProvider documentation <https://docs.quantum.ibm.com/api/qiskit/providers_basic_provider>`_.
-
-    A range of :code:`backend_options` that will be passed to the simulator and
-    a range of transpile options can be given as kwargs.
+    These options can be passed to this plugin device as keyword arguments.
 
     Args:
         wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -17,7 +17,6 @@ evaluation and differentiation of Qiskit Terra's BasicAer simulator
 using PennyLane.
 """
 import qiskit
-import warnings
 
 from semantic_version import Version
 

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -86,11 +86,6 @@ class BasicSimulatorDevice(QiskitDevice):
         shots (int or None): number of circuit evaluations/random samples used
             to estimate expectation values and variances of observables. For statevector backends,
             setting to ``None`` results in computing statistics like expectation values and variances analytically.
-
-    Keyword Args:
-        name (str): The name of the circuit. Default ``'circuit'``.
-        compile_backend (BaseBackend): The backend used for compilation. If you wish
-            to simulate a device compliant circuit, you can specify a backend here.
     """
 
     short_name = "qiskit.basicsim"

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -58,10 +58,9 @@ class BasicAerDevice(QiskitDevice):
 
         if Version(qiskit.__version__) > max_ver:
             raise RuntimeError(
-                f"The devices in the PennyLane Qiskit plugin are currently only compatible "
-                f"with versions of Qiskit below 0.46. You have version {qiskit.__version__} "
-                f"installed. Please downgrade Qiskit to use the devices. The devices will be "
-                f"updated in the coming weeks to be compatible with Qiskit 1.0!"
+                f"Qiskit has discontinued the BasicAer device, so it can only be used in"
+                f"versions of Qiskit below 0.46. You have version {qiskit.__version__} "
+                f"installed. Please downgrade Qiskit to use the 'qiskit.basicaer' device."
             )
 
         super().__init__(wires, provider=qiskit.BasicAer, backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -72,16 +72,13 @@ class BasicAerDevice(QiskitDevice):
 
 
 class BasicSimulatorDevice(QiskitDevice):
-    """A PennyLane device for the native Python Qiskit simulator BasicSimulator.
+    """A PennyLane device for the native Python Qiskit simulator from BasicProvider.
 
-    Please see the `Qiskit documentations <https://qiskit.org/documentation/>`_
-    further information on the backend options and transpile options.
+    For more information on the BasicSimulator backend options and transpile options, please visit the
+    `BasicProvider documentation <https://docs.quantum.ibm.com/api/qiskit/providers_basic_provider>`_.
 
     A range of :code:`backend_options` that will be passed to the simulator and
     a range of transpile options can be given as kwargs.
-
-    For more information on backends, please visit the
-    `BasicProvider documentation <https://docs.quantum.ibm.com/api/qiskit/providers_basic_provider>`_.
 
     Args:
         wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
@@ -109,7 +106,7 @@ class BasicSimulatorDevice(QiskitDevice):
                 f"The 'qiskit.simulator' device is not compatible with version of Qiskit prior "
                 f"to 1.0. You have version {qiskit.__version__} installed. For a Python simulator, "
                 f"use the 'qiskit.basicaer' device instead. Alternatively, upgrade Qiskit "
-                f"to use the 'qiskit.basicsim' device."
+                f"(see https://docs.quantum.ibm.com/start/install) to use the 'qiskit.basicsim' device."
             )
 
         super().__init__(wires, provider=BasicProvider(), backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -24,7 +24,7 @@ from .qiskit_device import QiskitDevice
 
 
 class BasicAerDevice(QiskitDevice):
-    """A PennyLane device for the native Python Qiskit simulator.
+    """A PennyLane device for the native Python Qiskit simulator BasicAer.
 
     Please see the `Qiskit documentations <https://qiskit.org/documentation/>`_
     further information on the backend options and transpile options.
@@ -38,7 +38,7 @@ class BasicAerDevice(QiskitDevice):
     Args:
         wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
-            or strings (``['ancilla', 'q1', 'q2']``).
+            or strings (``['aux_wire', 'q1', 'q2']``).
         backend (str): the desired backend
         shots (int or None): number of circuit evaluations/random samples used
             to estimate expectation values and variances of observables. For statevector backends,
@@ -60,7 +60,54 @@ class BasicAerDevice(QiskitDevice):
             raise RuntimeError(
                 f"Qiskit has discontinued the BasicAer device, so it can only be used in"
                 f"versions of Qiskit below 0.46. You have version {qiskit.__version__} "
-                f"installed. Please downgrade Qiskit to use the 'qiskit.basicaer' device."
+                f"installed. For a Python simulator, use the 'qiskit.basicsim' device "
+                f"instead. Alternatively, you can downgrade Qiskit to use the "
+                f"'qiskit.basicaer' device."
             )
 
         super().__init__(wires, provider=qiskit.BasicAer, backend=backend, shots=shots, **kwargs)
+
+
+class BasicSimulatorDevice(QiskitDevice):
+    """A PennyLane device for the native Python Qiskit simulator BasicSimulator.
+
+    Please see the `Qiskit documentations <https://qiskit.org/documentation/>`_
+    further information on the backend options and transpile options.
+
+    A range of :code:`backend_options` that will be passed to the simulator and
+    a range of transpile options can be given as kwargs.
+
+    For more information on backends, please visit the
+    `BasicProvider documentation <https://docs.quantum.ibm.com/api/qiskit/providers_basic_provider>`_.
+
+    Args:
+        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['aux_wire', 'q1', 'q2']``).
+        backend (str): the desired backend
+        shots (int or None): number of circuit evaluations/random samples used
+            to estimate expectation values and variances of observables. For statevector backends,
+            setting to ``None`` results in computing statistics like expectation values and variances analytically.
+
+    Keyword Args:
+        name (str): The name of the circuit. Default ``'circuit'``.
+        compile_backend (BaseBackend): The backend used for compilation. If you wish
+            to simulate a device compliant circuit, you can specify a backend here.
+    """
+
+    short_name = "qiskit.basicsim"
+
+    def __init__(self, wires, shots=1024, backend="basic_simulator", **kwargs):
+
+        min_version = Version("1.0.0")
+
+        if Version(qiskit.__version__) < min_version:
+            raise RuntimeError(
+                f"The 'qiskit.simulator' device is not compatible with version of Qiskit prior "
+                f"to 1.0. You have version {qiskit.__version__} installed. For a Python simulator, "
+                f"use the 'qiskit.basicaer' device instead. Alternatively, upgrade Qiskit "
+                f"to use the 'qiskit.basicsim' device."
+            )
+
+        from qiskit.providers.basic_provider import BasicProvider
+        super().__init__(wires, provider=BasicProvider(), backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -110,4 +110,5 @@ class BasicSimulatorDevice(QiskitDevice):
             )
 
         from qiskit.providers.basic_provider import BasicProvider
+
         super().__init__(wires, provider=BasicProvider(), backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -107,4 +107,16 @@ class BasicSimulatorDevice(QiskitDevice):
                 f"(see https://docs.quantum.ibm.com/start/install) to use the 'qiskit.basicsim' device."
             )
 
+        analytic_warning_message = (
+            "The plugin does not currently support analytic calculation of expectations, variances "
+            "and probabilities with the BasicProvider backend(s). Such statistics obtained from this "
+            "device are estimates based on samples."
+        )
+
+        # Raise a warning if no shots were specified
+        if not shots:
+            warnings.warn(self.analytic_warning_message, UserWarning)
+            shots = 1024
+
+
         super().__init__(wires, provider=BasicProvider(), backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/basic_aer.py
+++ b/pennylane_qiskit/basic_aer.py
@@ -57,12 +57,12 @@ class BasicAerDevice(QiskitDevice):
 
     def __init__(self, wires, shots=1024, backend="qasm_simulator", **kwargs):
 
-        max_ver = Version("0.45.3")
+        max_ver = Version("0.46")
 
         if Version(qiskit.__version__) > max_ver:
             raise RuntimeError(
                 f"Qiskit has discontinued the BasicAer device, so it can only be used in"
-                f"versions of Qiskit below 0.46. You have version {qiskit.__version__} "
+                f"versions of Qiskit below 1.0. You have version {qiskit.__version__} "
                 f"installed. For a Python simulator, use the 'qiskit.basicsim' device "
                 f"instead. Alternatively, you can downgrade Qiskit to use the "
                 f"'qiskit.basicaer' device."

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -140,7 +140,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         "Projector",
     }
 
-    hw_analytic_warning_message = (
+    analytic_warning_message = (
         "The analytic calculation of expectations, variances and "
         "probabilities is only supported on statevector backends, not on the {}. "
         "Such statistics obtained from this device are estimates based on samples."
@@ -174,7 +174,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         # Keep track if the user specified analytic to be True
         if shots is None and not self._is_state_backend:
             # Raise a warning if no shots were specified for a hardware device
-            warnings.warn(self.hw_analytic_warning_message.format(backend), UserWarning)
+            warnings.warn(self.analytic_warning_message.format(backend), UserWarning)
 
             self.shots = 1024
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -22,7 +22,6 @@ import inspect
 import warnings
 
 import numpy as np
-import qiskit
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.circuit import library as lib
 from qiskit.compiler import transpile

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -32,8 +32,6 @@ from qiskit.providers import Backend, QiskitBackendNotFoundError
 from pennylane import QubitDevice, DeviceError
 from pennylane.measurements import SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP
 
-from semantic_version import Version
-
 from ._version import __version__
 
 SAMPLE_TYPES = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
@@ -151,16 +149,6 @@ class QiskitDevice(QubitDevice, abc.ABC):
     _eigs = {}
 
     def __init__(self, wires, provider, backend, shots=1024, **kwargs):
-
-        max_ver = Version("0.45.3")
-
-        if Version(qiskit.__version__) > max_ver:
-            raise RuntimeError(
-                f"The devices in the PennyLane Qiskit plugin are currently only compatible "
-                f"with versions of Qiskit below 0.46. You have version {qiskit.__version__} "
-                f"installed. Please downgrade Qiskit to use the devices. The devices will be "
-                f"updated in the coming weeks to be compatible with Qiskit 1.0!"
-            )
 
         super().__init__(wires=wires, shots=shots)
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -184,9 +184,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
         backend_qubits = self.backend.configuration().n_qubits
         # if the backend has a set number of qubits, ensure wires doesn't exceed (some simulators have n_qubits=None)
         if backend_qubits and len(self.wires) > int(backend_qubits):
-            raise ValueError(
-                f"Backend '{backend}' supports maximum {backend_qubits} wires"
-            )
+            raise ValueError(f"Backend '{backend}' supports maximum {backend_qubits} wires")
 
         # Initialize inner state
         self.reset()

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -121,6 +121,7 @@ class QiskitDevice(QubitDevice, abc.ABC):
     _operation_map = QISKIT_OPERATION_MAP
     _state_backends = {
         "statevector_simulator",
+        "simulator_statevector",
         "unitary_simulator",
         "aer_simulator_statevector",
         "aer_simulator_unitary",
@@ -180,10 +181,11 @@ class QiskitDevice(QubitDevice, abc.ABC):
         self._capabilities["returns_state"] = self._is_state_backend
 
         # Perform validation against backend
-        b = self.backend
-        if len(self.wires) > int(b.configuration().n_qubits):
+        backend_qubits = self.backend.configuration().n_qubits
+        # if the backend has a set number of qubits, ensure wires doesn't exceed (some simulators have n_qubits=None)
+        if backend_qubits and len(self.wires) > int(backend_qubits):
             raise ValueError(
-                f"Backend '{backend}' supports maximum {b.configuration().n_qubits} wires"
+                f"Backend '{backend}' supports maximum {backend_qubits} wires"
             )
 
         # Initialize inner state

--- a/requirements-ci-legacy.txt
+++ b/requirements-ci-legacy.txt
@@ -1,0 +1,5 @@
+pennylane>=0.32
+qiskit<0.46
+qiskit-ibm-runtime<0.21
+numpy
+sympy

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 pennylane>=0.32
-qiskit<0.46
+qiskit
 numpy
 sympy

--- a/requirements-ci0.txt
+++ b/requirements-ci0.txt
@@ -1,4 +1,0 @@
-pennylane>=0.32
-qiskit
-numpy
-sympy

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ with open("README.rst", "r") as fh:
 requirements = [
     "qiskit>=0.32",
     "qiskit-aer",
-    "qiskit-ibm-runtime<0.21",
     "qiskit-ibm-provider",
+    "qiskit-ibm-runtime",
     "pennylane>=0.30",
     "numpy",
     "networkx>=2.2",

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ info = {
             'qiskit.remote = pennylane_qiskit:RemoteDevice',
             'qiskit.aer = pennylane_qiskit:AerDevice',
             'qiskit.basicaer = pennylane_qiskit:BasicAerDevice',
+            'qiskit.basicsim = pennylane_qiskit:BasicSimulatorDevice',
             'qiskit.ibmq = pennylane_qiskit:IBMQDevice',
             'qiskit.ibmq.circuit_runner = pennylane_qiskit:IBMQCircuitRunnerDevice',
             'qiskit.ibmq.sampler = pennylane_qiskit:IBMQSamplerDevice'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,9 +125,13 @@ def device(request, backend, shots):
             pytest.skip("Hardware simulators do not support analytic mode")
 
     if backend == "aer_simulator" and not issubclass(request.param, AerDevice):
+        print("I should be skipping this test")
         pytest.skip("Only the AerDevice can use the aer_simulator backend")
 
     if issubclass(request.param, BasicSimulatorDevice) and backend != "basic_simulator":
+        pytest.skip("BasicSimulator is the only supported backend for the BasicSimulatorDevice")
+
+    if backend == "basic_simulator" and not issubclass(request.param, BasicSimulatorDevice):
         pytest.skip("BasicSimulator is the only supported backend for the BasicSimulatorDevice")
 
     def _device(n, device_options=None):
@@ -145,6 +149,9 @@ def state_vector_device(request, statevector_backend, shots):
         pytest.skip("Only the AerDevice can use the aer_simulator backend")
 
     if issubclass(request.param, BasicSimulatorDevice) and backend != "basic_simulator":
+        pytest.skip("BasicSimulator is the only supported backend for the BasicSimulatorDevice")
+
+    if backend == "basic_simulator" and not issubclass(request.param, BasicSimulatorDevice):
         pytest.skip("BasicSimulator is the only supported backend for the BasicSimulatorDevice")
 
     def _device(n):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,13 +47,14 @@ if Version(qiskit.__version__) < Version("1.0.0"):
     ]
 else:
     test_devices = [AerDevice, BasicSimulatorDevice]
-    hw_backends = ["ibmq_qasm_simulator", "aer_simulator", "basic_simulator"]
+    hw_backends = ["qasm_simulator", "aer_simulator", "basic_simulator"]
     state_backends = [
         "statevector_simulator",
         "unitary_simulator",
         "aer_simulator_statevector",
         "aer_simulator_unitary",
     ]
+
 
 @pytest.fixture
 def skip_if_no_account():
@@ -126,7 +127,7 @@ def device(request, backend, shots):
     if backend == "aer_simulator" and not issubclass(request.param, AerDevice):
         pytest.skip("Only the AerDevice can use the aer_simulator backend")
 
-    if issubclass(request.param, BasicSimulatorDevice) and backend!="basic_simulator":
+    if issubclass(request.param, BasicSimulatorDevice) and backend != "basic_simulator":
         pytest.skip("BasicSimulator is the only supported backend for the BasicSimulatorDevice")
 
     def _device(n, device_options=None):
@@ -139,11 +140,11 @@ def device(request, backend, shots):
 
 @pytest.fixture(params=test_devices)
 def state_vector_device(request, statevector_backend, shots):
-        
+
     if backend == "aer_simulator" and not issubclass(request.param, AerDevice):
         pytest.skip("Only the AerDevice can use the aer_simulator backend")
 
-    if issubclass(request.param, BasicSimulatorDevice) and backend!="basic_simulator":
+    if issubclass(request.param, BasicSimulatorDevice) and backend != "basic_simulator":
         pytest.skip("BasicSimulator is the only supported backend for the BasicSimulatorDevice")
 
     def _device(n):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,10 @@ This module contains tests for PennyLane runtime programs.
 import os
 import pytest
 import numpy as np
+import qiskit
 
 import pennylane as qml
+from semantic_version import Version
 from qiskit_ibm_provider import IBMProvider
 from pennylane_qiskit import AerDevice, BasicAerDevice
 
@@ -43,6 +45,11 @@ state_backends = [
     "aer_simulator_unitary",
 ]
 hw_backends = ["qasm_simulator", "aer_simulator"]
+
+if Version(qiskit.__version__) < Version("1.0.0"):
+    test_devices = [AerDevice, BasicAerDevice]
+else:
+    test_devices = [AerDevice]
 
 
 @pytest.fixture
@@ -106,7 +113,7 @@ def hardware_backend(request):
     return request.param
 
 
-@pytest.fixture(params=[AerDevice, BasicAerDevice])
+@pytest.fixture(params=test_devices)
 def device(request, backend, shots):
     if backend not in state_backends and shots is None:
         pytest.skip("Hardware simulators do not support analytic mode")
@@ -124,7 +131,7 @@ def device(request, backend, shots):
     return _device
 
 
-@pytest.fixture(params=[AerDevice, BasicAerDevice])
+@pytest.fixture(params=test_devices)
 def state_vector_device(request, statevector_backend, shots):
     if (issubclass(request.param, AerDevice) and "aer" not in statevector_backend) or (
         issubclass(request.param, BasicAerDevice) and "aer" in statevector_backend

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,6 +16,7 @@ from conftest import state_backends
 
 if Version(qiskit.__version__) < Version("1.0.0"):
     pldevices = [("qiskit.aer", qiskit_aer.Aer), ("qiskit.basicaer", qiskit.BasicAer)]
+
     def check_provider_backend_compatibility(pldevice, backend_name):
         dev_name, _ = pldevice
         if (dev_name == "qiskit.aer" and "aer" not in backend_name) or (
@@ -23,6 +24,7 @@ if Version(qiskit.__version__) < Version("1.0.0"):
         ):
             return (False, "Only the AerSimulator is supported on AerDevice")
         return True, None
+
 else:
     from qiskit.providers.basic_provider import BasicProvider
 
@@ -223,7 +225,9 @@ class TestKeywordArguments:
 
         cache = []
         with monkeypatch.context() as m:
-            m.setattr(qiskit_aer.AerSimulator, "set_options", lambda *args, **kwargs: cache.append(kwargs))
+            m.setattr(
+                qiskit_aer.AerSimulator, "set_options", lambda *args, **kwargs: cache.append(kwargs)
+            )
             dev = qml.device("qiskit.aer", wires=2, noise_model="test value")
         assert cache[-1] == {"noise_model": "test value"}
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,12 +15,12 @@ from qiskit.providers import QiskitBackendNotFoundError
 from conftest import state_backends
 
 if Version(qiskit.__version__) < Version("1.0.0"):
-    pldevices = [("qiskit.aer", qiskit_aer.Aer),
-                 ("qiskit.basicaer", qiskit.BasicAer)]
+    pldevices = [("qiskit.aer", qiskit_aer.Aer), ("qiskit.basicaer", qiskit.BasicAer)]
 else:
     from qiskit.providers.basic_provider import BasicProvider
-    pldevices = [("qiskit.aer", qiskit_aer.Aer),
-                 ("qiskit.basicsim", BasicProvider)]
+
+    pldevices = [("qiskit.aer", qiskit_aer.Aer), ("qiskit.basicsim", BasicProvider)]
+
 
 class TestDeviceIntegration:
     """Test the devices work correctly from the PennyLane frontend."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,10 +16,26 @@ from conftest import state_backends
 
 if Version(qiskit.__version__) < Version("1.0.0"):
     pldevices = [("qiskit.aer", qiskit_aer.Aer), ("qiskit.basicaer", qiskit.BasicAer)]
+    def check_provider_backend_compatibility(pldevice, backend_name):
+        dev_name, _ = pldevice
+        if (dev_name == "qiskit.aer" and "aer" not in backend_name) or (
+            dev_name == "qiskit.basicaer" and "aer" in backend_name
+        ):
+            return (False, "Only the AerSimulator is supported on AerDevice")
+        return True, None
 else:
     from qiskit.providers.basic_provider import BasicProvider
 
-    pldevices = [("qiskit.aer", qiskit_aer.Aer), ("qiskit.basicsim", BasicProvider)]
+    pldevices = [("qiskit.aer", qiskit_aer.Aer), ("qiskit.basicsim", BasicProvider())]
+
+    def check_provider_backend_compatibility(pldevice, backend_name):
+        dev_name, _ = pldevice
+        if dev_name == "qiskit.aer" and backend_name == "basic_simulator":
+            return (False, "basic_simulator is not supported on the AerDevice")
+
+        if dev_name == "qiskit.basicsim" and backend_name != "basic_simulator":
+            return (False, "Only the basic_simulator backend works with the BasicSimulatorDevice")
+        return True, None
 
 
 class TestDeviceIntegration:
@@ -28,10 +44,11 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize("d", pldevices)
     def test_load_device(self, d, backend):
         """Test that the qiskit device loads correctly"""
-        if (d[0] == "qiskit.aer" and "aer" not in backend) or (
-            d[0] == "qiskit.basicaer" and "aer" in backend
-        ):
-            pytest.skip("Only the AerSimulator is supported on AerDevice")
+
+        # check compatibility between provider and backend, and skip if incompatible
+        is_compatible, failure_msg = check_provider_backend_compatibility(d, backend)
+        if not is_compatible:
+            pytest.skip(failure_msg)
 
         dev = qml.device(d[0], wires=2, backend=backend, shots=1024)
         assert dev.num_wires == 2
@@ -62,12 +79,13 @@ class TestDeviceIntegration:
         """Test that the qiskit.remote device loads correctly when passed a provider and a backend
         name. This test is equivalent to `test_load_device` but on the qiskit.remote device instead
         of specialized devices that expose more configuration options."""
-        _, provider = d
 
-        if (d[0] == "qiskit.aer" and "aer" not in backend) or (
-            d[0] == "qiskit.basicaer" and "aer" in backend
-        ):
-            pytest.skip("Only the AerSimulator is supported on AerDevice")
+        # check compatibility between provider and backend, and skip if incompatible
+        is_compatible, failure_msg = check_provider_backend_compatibility(d, backend)
+        if not is_compatible:
+            pytest.skip(failure_msg)
+
+        _, provider = d
 
         dev = qml.device("qiskit.remote", wires=2, provider=provider, backend=backend, shots=1024)
         assert dev.num_wires == 2
@@ -108,10 +126,11 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize("shots", [None, 8192])
     def test_one_qubit_circuit(self, shots, d, backend, tol):
         """Test that devices provide correct result for a simple circuit"""
-        if (d[0] == "qiskit.aer" and "aer" not in backend) or (
-            d[0] == "qiskit.basicaer" and "aer" in backend
-        ):
-            pytest.skip("Only the AerSimulator is supported on AerDevice")
+
+        # check compatibility between provider and backend, and skip if incompatible
+        is_compatible, failure_msg = check_provider_backend_compatibility(d, backend)
+        if not is_compatible:
+            pytest.skip(failure_msg)
 
         if backend not in state_backends and shots is None:
             pytest.skip("Hardware simulators do not support analytic mode")
@@ -137,10 +156,10 @@ class TestDeviceIntegration:
     def test_basis_state_and_rot(self, shots, d, backend, tol):
         """Integration test for the BasisState and Rot operations for non-analytic mode."""
 
-        if (d[0] == "qiskit.aer" and "aer" not in backend) or (
-            d[0] == "qiskit.basicaer" and "aer" in backend
-        ):
-            pytest.skip("Only the AerSimulator is supported on AerDevice")
+        # check compatibility between provider and backend, and skip if incompatible
+        is_compatible, failure_msg = check_provider_backend_compatibility(d, backend)
+        if not is_compatible:
+            pytest.skip(failure_msg)
 
         dev = qml.device(d[0], wires=1, backend=backend, shots=shots)
 
@@ -204,7 +223,7 @@ class TestKeywordArguments:
 
         cache = []
         with monkeypatch.context() as m:
-            m.setattr(aer.AerSimulator, "set_options", lambda *args, **kwargs: cache.append(kwargs))
+            m.setattr(qiskit_aer.AerSimulator, "set_options", lambda *args, **kwargs: cache.append(kwargs))
             dev = qml.device("qiskit.aer", wires=2, noise_model="test value")
         assert cache[-1] == {"noise_model": "test value"}
 
@@ -505,8 +524,8 @@ class TestNoise:
 
     def test_noise_applied(self):
         """Test that the qiskit noise model is applied correctly"""
-        noise_model = aer.noise.NoiseModel()
-        bit_flip = aer.noise.pauli_error([("X", 1), ("I", 0)])
+        noise_model = qiskit_aer.noise.NoiseModel()
+        bit_flip = qiskit_aer.noise.pauli_error([("X", 1), ("I", 0)])
 
         # Create a noise model where the RX operation always flips the bit
         noise_model.add_all_qubit_quantum_error(bit_flip, ["z", "rz"])
@@ -529,10 +548,11 @@ class TestBatchExecution:
     def test_one_qubit_circuit_batch_params(self, shots, d, backend, tol, mocker):
         """Test that devices provide correct result for a simple circuit using
         the batch_params transform."""
-        if (d[0] == "qiskit.aer" and "aer" not in backend) or (
-            d[0] == "qiskit.basicaer" and "aer" in backend
-        ):
-            pytest.skip("Only the AerSimulator is supported on AerDevice")
+
+        # check compatibility between provider and backend, and skip if incompatible
+        is_compatible, failure_msg = check_provider_backend_compatibility(d, backend)
+        if not is_compatible:
+            pytest.skip(failure_msg)
 
         if backend not in state_backends and shots is None:
             pytest.skip("Hardware simulators do not support analytic mode")
@@ -568,10 +588,11 @@ class TestBatchExecution:
     def test_batch_execute_parameter_shift(self, shots, d, backend, tol, mocker):
         """Test that devices provide correct result computing the gradient of a
         circuit using the parameter-shift rule and the batch execution pipeline."""
-        if (d[0] == "qiskit.aer" and "aer" not in backend) or (
-            d[0] == "qiskit.basicaer" and "aer" in backend
-        ):
-            pytest.skip("Only the AerSimulator is supported on AerDevice")
+
+        # check compatibility between provider and backend, and skip if incompatible
+        is_compatible, failure_msg = check_provider_backend_compatibility(d, backend)
+        if not is_compatible:
+            pytest.skip(failure_msg)
 
         if backend not in state_backends and shots is None:
             pytest.skip("Hardware simulators do not support analytic mode")

--- a/tests/test_new_qiskit_temp.py
+++ b/tests/test_new_qiskit_temp.py
@@ -5,7 +5,7 @@ import qiskit
 from semantic_version import Version
 from unittest.mock import Mock
 
-from .basic_aer import BasicSimulatorDevice
+from pennylane_qiskit import BasicSimulatorDevice
 
 @pytest.mark.skipif(Version(qiskit.__version__) < Version("1.0.0"),
                     reason="versions below 1.0 are compatible with BasicAer")

--- a/tests/test_new_qiskit_temp.py
+++ b/tests/test_new_qiskit_temp.py
@@ -7,8 +7,11 @@ from unittest.mock import Mock
 
 from pennylane_qiskit import BasicSimulatorDevice
 
-@pytest.mark.skipif(Version(qiskit.__version__) < Version("1.0.0"),
-                    reason="versions below 1.0 are compatible with BasicAer")
+
+@pytest.mark.skipif(
+    Version(qiskit.__version__) < Version("1.0.0"),
+    reason="versions below 1.0 are compatible with BasicAer",
+)
 def test_error_is_raised_if_initalizing_basicaer_device(monkeypatch):
     """Test that when Qiskit 1.0 is installed, an error is raised if you try
     to initialize the 'qiskit.basicaer' device."""
@@ -20,8 +23,11 @@ def test_error_is_raised_if_initalizing_basicaer_device(monkeypatch):
     ):
         qml.device("qiskit.basicaer", wires=2)
 
-@pytest.mark.skipif(Version(qiskit.__version__) >= Version("1.0.0"),
-                    reason="versions 1.0 and above are compatible with BasicSimulator")
+
+@pytest.mark.skipif(
+    Version(qiskit.__version__) >= Version("1.0.0"),
+    reason="versions 1.0 and above are compatible with BasicSimulator",
+)
 def test_error_is_raised_if_initalizing_basic_simulator_device(monkeypatch):
     """Test that when a version of Qiskit below 1.0 is installed, an error is raised if you try
     to initialize the BasicSimulatorDevice."""

--- a/tests/test_new_qiskit_temp.py
+++ b/tests/test_new_qiskit_temp.py
@@ -5,13 +5,13 @@ import qiskit
 from semantic_version import Version
 from unittest.mock import Mock
 
+from .basic_aer import BasicSimulatorDevice
 
-def test_error_is_raised_if_initalizing_device(monkeypatch):
+@pytest.mark.skipif(Version(qiskit.__version__) < Version("1.0.0"),
+                    reason="versions below 1.0 are compatible with BasicAer")
+def test_error_is_raised_if_initalizing_basicaer_device(monkeypatch):
     """Test that when Qiskit 1.0 is installed, an error is raised if you try
     to initialize the 'qiskit.basicaer' device."""
-
-    # skip in the 0.X.X tests
-    pytest.skipif(Version(qiskit.__version__) < Version("1.0.0"))
 
     # test that the correct error is actually raised in Qiskit 1.0 (rather than fx an import error)
     with pytest.raises(
@@ -20,3 +20,15 @@ def test_error_is_raised_if_initalizing_device(monkeypatch):
     ):
         qml.device("qiskit.basicaer", wires=2)
 
+@pytest.mark.skipif(Version(qiskit.__version__) >= Version("1.0.0"),
+                    reason="versions 1.0 and above are compatible with BasicSimulator")
+def test_error_is_raised_if_initalizing_basic_simulator_device(monkeypatch):
+    """Test that when a version of Qiskit below 1.0 is installed, an error is raised if you try
+    to initialize the BasicSimulatorDevice."""
+
+    # test that the correct error is actually raised in Qiskit 1.0 (rather than fx an import error)
+    with pytest.raises(
+        RuntimeError,
+        match="Qiskit has discontinued the BasicAer device",
+    ):
+        BasicSimulatorDevice(wires=2)

--- a/tests/test_new_qiskit_temp.py
+++ b/tests/test_new_qiskit_temp.py
@@ -2,6 +2,7 @@ import pytest
 import pennylane as qml
 import qiskit
 
+from semantic_version import Version
 from unittest.mock import Mock
 
 

--- a/tests/test_new_qiskit_temp.py
+++ b/tests/test_new_qiskit_temp.py
@@ -35,6 +35,6 @@ def test_error_is_raised_if_initalizing_basic_simulator_device(monkeypatch):
     # test that the correct error is actually raised in Qiskit 1.0 (rather than fx an import error)
     with pytest.raises(
         RuntimeError,
-        match="Qiskit has discontinued the BasicAer device",
+        match="device is not compatible with version of Qiskit prior to 1.0",
     ):
         BasicSimulatorDevice(wires=2)

--- a/tests/test_new_qiskit_temp.py
+++ b/tests/test_new_qiskit_temp.py
@@ -5,30 +5,17 @@ import qiskit
 from unittest.mock import Mock
 
 
-@pytest.mark.parametrize(
-    "device_name",
-    [
-        "qiskit.aer",
-        "qiskit.basicaer",
-        "qiskit.remote",
-    ],
-)
-def test_error_is_raised_if_initalizing_device(monkeypatch, device_name):
+def test_error_is_raised_if_initalizing_device(monkeypatch):
     """Test that when Qiskit 1.0 is installed, an error is raised if you try
-    to initialize a device. This is a temporary test and will be removed along
-    with the error one everything is compatible with 1.0"""
+    to initialize the 'qiskit.basicaer' device."""
 
-    # make it not fail in the normal tests (running 0.46)
-    if qiskit.__version__ != "1.0.0":
-        monkeypatch.setattr(qiskit, "__version__", "1.0.0")
+    # skip in the 0.X.X tests
+    pytest.skipif(Version(qiskit.__version__) < Version("1.0.0"))
 
     # test that the correct error is actually raised in Qiskit 1.0 (rather than fx an import error)
     with pytest.raises(
         RuntimeError,
-        match="The devices in the PennyLane Qiskit plugin are currently only compatible with versions of Qiskit below 0.46",
+        match="Qiskit has discontinued the BasicAer device",
     ):
-        if device_name in ["qiskit.aer", "qiskit.basicaer"]:
-            qml.device(device_name, wires=2)
-        else:
-            # use a Mock backend to avoid call to the remote service
-            qml.device(device_name, wires=2, backend=Mock())
+        qml.device("qiskit.basicaer", wires=2)
+

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -79,7 +79,6 @@ class TestAnalyticWarningHWSimulator:
         assert len(recwarn) == 0
 
 
-
 class TestAerBackendOptions:
     """Test the backend options of Aer backends."""
 

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -56,7 +56,7 @@ class TestAnalyticWarningHWSimulator:
             pytest.skip("Not supported on basicaer")
 
         with pytest.warns(UserWarning) as record:
-            dev = qml.device("qiskit.basicaer", backend=hardware_backend, wires=2, shots=None)
+            dev = qml.device("qiskit.ibmq", backend=hardware_backend, wires=2, shots=None)
 
         # check that only one warning was raised
         assert len(record) == 1
@@ -65,7 +65,7 @@ class TestAnalyticWarningHWSimulator:
             record[0].message.args[0] == "The analytic calculation of "
             "expectations, variances and probabilities is only supported on "
             "statevector backends, not on the {}. Such statistics obtained from this "
-            "device are estimates based on samples.".format(dev.backend)
+            "device are estimates based on samples.".format(dev.backend.name)
         )
 
     def test_no_warning_raised_for_software_backend_analytic_expval(
@@ -76,7 +76,7 @@ class TestAnalyticWarningHWSimulator:
         if "aer" in statevector_backend:
             pytest.skip("Not supported on basicaer")
 
-        dev = qml.device("qiskit.basicaer", backend=statevector_backend, wires=2, shots=None)
+        dev = qml.device("qiskit.ibmq", backend=statevector_backend, wires=2, shots=None)
 
         # check that no warnings were raised
         assert len(recwarn) == 0

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -49,14 +49,12 @@ class TestTranspilationOptionInitialization:
 class TestAnalyticWarningHWSimulator:
     """Tests the warnings for when the analytic attribute of a device is set to true"""
 
-    def test_warning_raised_for_hardware_backend_analytic_expval(self, hardware_backend, recorder):
+    def test_warning_raised_for_hardware_backend_analytic_expval(self, recorder):
         """Tests that a warning is raised if the analytic attribute is true on
         hardware simulators when calculating the expectation"""
-        if "aer" in hardware_backend:
-            pytest.skip("Not supported on basicaer")
 
         with pytest.warns(UserWarning) as record:
-            dev = qml.device("qiskit.ibmq", backend=hardware_backend, wires=2, shots=None)
+            dev = qml.device("qiskit.ibmq", backend="ibmq_qasm_simulator", wires=2, shots=None)
 
         # check that only one warning was raised
         assert len(record) == 1
@@ -69,14 +67,12 @@ class TestAnalyticWarningHWSimulator:
         )
 
     def test_no_warning_raised_for_software_backend_analytic_expval(
-        self, statevector_backend, recorder, recwarn
+        self, recorder, recwarn
     ):
         """Tests that no warning is raised if the analytic attribute is true on
         statevector simulators when calculating the expectation"""
-        if "aer" in statevector_backend:
-            pytest.skip("Not supported on basicaer")
 
-        dev = qml.device("qiskit.ibmq", backend=statevector_backend, wires=2, shots=None)
+        dev = qml.device("qiskit.ibmq", backend="simulator_statevector", wires=2, shots=None)
 
         # check that no warnings were raised
         assert len(recwarn) == 0

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -54,7 +54,7 @@ class TestAnalyticWarningHWSimulator:
         hardware simulators when calculating the expectation"""
 
         with pytest.warns(UserWarning) as record:
-            dev = qml.device("qiskit.ibmq", backend="ibmq_qasm_simulator", wires=2, shots=None)
+            dev = qml.device("qiskit.aer", backend="aer_simulator", wires=2, shots=None)
 
         # check that only one warning was raised
         assert len(record) == 1
@@ -66,16 +66,18 @@ class TestAnalyticWarningHWSimulator:
             "device are estimates based on samples.".format(dev.backend.name)
         )
 
+    @pytest.mark.parametrize("method", ["unitary", "statevector"])
     def test_no_warning_raised_for_software_backend_analytic_expval(
-        self, recorder, recwarn
+        self, method, recorder, recwarn
     ):
         """Tests that no warning is raised if the analytic attribute is true on
         statevector simulators when calculating the expectation"""
 
-        dev = qml.device("qiskit.ibmq", backend="simulator_statevector", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", backend="aer_simulator", method=method, wires=2, shots=None)
 
         # check that no warnings were raised
         assert len(recwarn) == 0
+
 
 
 class TestAerBackendOptions:


### PR DESCRIPTION
Finishing the work started before the 0.35 release of getting the devices up to date and tested with Qiskit 1.0. We continue also running the tests with Qiskit 0.45.3, to check backward compatibility.

There are a _few_ small tweaks to source code to get it compatible, but most of that got done before last release. 

This PR is mostly 

- CI changes to run the tests with both 1.0 and 0.45,
- test changes so the backends and providers being used in tests exist and are compatible with the Qiskit version,
- documentation updates, and 
- adding a new device because they've replaced `BasicAer` with `BasicSimulator` going forward