### PR TITLE
Remove use of from_qasm_file in test case

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -272,7 +272,8 @@ class TestLoadIntegration:
         with open(apply_hadamard, "w") as f:
             f.write(TestLoadIntegration.hadamard_qasm)
 
-        hadamard = qml.from_qasm_file(apply_hadamard)
+        with open(apply_hadamard, "r") as f:
+            hadamard = qml.from_qasm(f.read())
 
         dev = qml.device("default.qubit", wires=2)
 


### PR DESCRIPTION
`from_qasm_file` is deprecated. Removes the use of `from_qasm_file` from test cases. Instead, read a file manually and use `from_qasm`.