### PR TITLE
Fix typo

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -283,7 +283,7 @@ class TestConverter:
 
     def test_quantum_circuit_error_not_qiskit_circuit_passed(self, recorder):
         """Tests the load method raises a ValueError, if something
-        that is not a QuanctumCircuit was passed."""
+        that is not a QuantumCircuit was passed."""
 
         qc = qml.PauliZ(0)
 


### PR DESCRIPTION
Found a simple typo. Changed `Quanctum` to `Quantum`.