### PR TITLE
Move off of "ibmq_qasm_simulator" and towards using AerSimulator for qiskit tests

### DIFF
--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -288,7 +288,6 @@ class QiskitDevice2(Device):
         self._backend = backend
         self._compile_backend = compile_backend if compile_backend else backend
 
-        # ToDo: possibly things fail if this is not a QiskitRuntimeService - confirm and decide how to handle (SC 55725)
         self._service = getattr(backend, "_service", None)
         self._use_primitives = use_primitives
         self._session = session

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -279,7 +279,7 @@ class QiskitDevice2(Device):
         self._compile_backend = compile_backend if compile_backend else backend
 
         # ToDo: possibly things fail if this is not a QiskitRuntimeService - confirm and decide how to handle (SC 55725)
-        self._service = backend._service
+        self._service = getattr(backend, "_service", None)
         self._use_primitives = use_primitives
         self._session = session
 

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -546,13 +546,18 @@ class QiskitDevice2(Device):
         }
 
         # Send circuits to the cloud for execution by the circuit-runner program.
-        job = self.service.run(
-            program_id="circuit-runner",
-            options=options,
-            inputs=program_inputs,
-            session_id=session.session_id,
-        )
-        self._current_job = job.result(decoder=RunnerResult)
+        # Cloud simulators will be deprecated on May 15th so this will be exclusively for real hardware devices.
+        if self.service:
+            job = self.service.run(
+                program_id="circuit-runner",
+                options=options,
+                inputs=program_inputs,
+                session_id=session.session_id,
+            )
+            self._current_job = job.result(decoder=RunnerResult)
+        else:  # Uses local simulator instead. After May 15th, all simulations will use this logic instead.
+            job = self.backend.run(compiled_circuits, options=options)  # Missing shots
+            self._current_job = job.result()
 
         results = []
 

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -523,6 +523,12 @@ class QiskitDevice2(Device):
 
     def _execute_runtime_service(self, circuits, session):
         """Execution using old runtime_service (can't use runtime sessions)"""
+
+        # The legacy backend.run() interface in Qiskit Runtime, which was used as the dedicated “direct hardware access” entry point, has been deprecated by Qiskit.
+        # The new SamplerV2 class now fulfills this role. Support for the backend.run() will be dropped on or around October 15, 2024.
+        # Please refer to the migration guide (https://docs.quantum.ibm.com/api/migration-guides/qiskit-runtime) for instructions on how to migrate any existing code.
+        # This corresponds to the "circuit-runner" and "qasm3-runner" programs if you are invoking the REST API directly.
+
         # update kwargs in case Options has been modified since last execution
         self._update_kwargs()
 

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -31,6 +31,7 @@ from qiskit.providers import BackendV2
 from qiskit_ibm_runtime import Session, Sampler, Estimator
 from qiskit_ibm_runtime.constants import RunnerResult
 from qiskit_ibm_runtime.options import Options
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
 
 from pennylane import transform
 from pennylane.transforms.core import TransformProgram
@@ -475,6 +476,7 @@ class QiskitDevice2(Device):
         circuits: QuantumTape_or_Batch,
         execution_config: ExecutionConfig = DefaultExecutionConfig,
     ) -> Result_or_ResultBatch:
+
         session = self._session or Session(backend=self.backend)
 
         if not self._use_primitives:

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -476,11 +476,8 @@ class QiskitDevice2(Device):
         circuits: QuantumTape_or_Batch,
         execution_config: ExecutionConfig = DefaultExecutionConfig,
     ) -> Result_or_ResultBatch:
-        
-        try: 
-            session = self._session or Session(backend=self.backend)
-        except QiskitBackendNotFoundError:
-            session = None
+
+        session = self._session or Session(backend=self.backend)
 
         if not self._use_primitives:
             results = self._execute_runtime_service(circuits, session=session)
@@ -509,8 +506,7 @@ class QiskitDevice2(Device):
                     results.append(execute_fn(circ, session))
                 yield results
             finally:
-                if session:
-                    session.close()
+                session.close()
 
         with execute_circuits(session) as results:
             return results

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -526,7 +526,7 @@ class QiskitDevice2(Device):
 
         # The legacy ``backend.run()`` interface in Qiskit Runtime, which was used as the dedicated “direct hardware access” entry point, has been deprecated by Qiskit.
         # The new SamplerV2 class now fulfills this role. Support for the backend.run() will be dropped on or around October 15, 2024.
-        # Please refer to the migration guide (https://docs.quantum.ibm.com/api/migration-guides/qiskit-runtime) for instructions on how to migrate any existing code.
+        # Please refer to the `migration guide <https://docs.quantum.ibm.com/api/migration-guides/qiskit-runtime>`_ for instructions on how to migrate any existing code.
         # This corresponds to the "circuit-runner" and "qasm3-runner" programs if you are invoking the REST API directly.
 
         # update kwargs in case Options has been modified since last execution

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -524,7 +524,7 @@ class QiskitDevice2(Device):
     def _execute_runtime_service(self, circuits, session):
         """Execution using old runtime_service (can't use runtime sessions)"""
 
-        # The legacy backend.run() interface in Qiskit Runtime, which was used as the dedicated “direct hardware access” entry point, has been deprecated by Qiskit.
+        # The legacy ``backend.run()`` interface in Qiskit Runtime, which was used as the dedicated “direct hardware access” entry point, has been deprecated by Qiskit.
         # The new SamplerV2 class now fulfills this role. Support for the backend.run() will be dropped on or around October 15, 2024.
         # Please refer to the migration guide (https://docs.quantum.ibm.com/api/migration-guides/qiskit-runtime) for instructions on how to migrate any existing code.
         # This corresponds to the "circuit-runner" and "qasm3-runner" programs if you are invoking the REST API directly.

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -556,7 +556,10 @@ class QiskitDevice2(Device):
             )
             self._current_job = job.result(decoder=RunnerResult)
         else:  # Uses local simulator instead. After May 15th, all simulations will use this logic instead.
-            job = self.backend.run(compiled_circuits, options=options)  # Missing shots
+            self.options.execution.shots = program_inputs["shots"]
+            job = self.backend.run(
+                compiled_circuits, options=self.options
+            )  # Missing shots potentially
             self._current_job = job.result()
 
         results = []

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -527,6 +527,7 @@ class QiskitDevice2(Device):
         # The new SamplerV2 class now fulfills this role. Support for the backend.run() will be dropped on or around October 15, 2024.
         # Please refer to the `migration guide <https://docs.quantum.ibm.com/api/migration-guides/qiskit-runtime>`_ for instructions on how to migrate any existing code.
         # This corresponds to the "circuit-runner" and "qasm3-runner" programs if you are invoking the REST API directly.
+        # ToDo: deprecate this by or around October 15, 2024.
 
         # update kwargs in case Options has been modified since last execution
         self._update_kwargs()

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -485,7 +485,6 @@ class QiskitDevice2(Device):
         circuits: QuantumTape_or_Batch,
         execution_config: ExecutionConfig = DefaultExecutionConfig,
     ) -> Result_or_ResultBatch:
-
         session = self._session or Session(backend=self.backend)
 
         if not self._use_primitives:

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -476,8 +476,11 @@ class QiskitDevice2(Device):
         circuits: QuantumTape_or_Batch,
         execution_config: ExecutionConfig = DefaultExecutionConfig,
     ) -> Result_or_ResultBatch:
-
-        session = self._session or Session(backend=self.backend)
+        
+        try: 
+            session = self._session or Session(backend=self.backend)
+        except QiskitBackendNotFoundError:
+            session = None
 
         if not self._use_primitives:
             results = self._execute_runtime_service(circuits, session=session)
@@ -506,7 +509,8 @@ class QiskitDevice2(Device):
                     results.append(execute_fn(circ, session))
                 yield results
             finally:
-                session.close()
+                if session:
+                    session.close()
 
         with execute_circuits(session) as results:
             return results

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -31,7 +31,6 @@ from qiskit.providers import BackendV2
 from qiskit_ibm_runtime import Session, Sampler, Estimator
 from qiskit_ibm_runtime.constants import RunnerResult
 from qiskit_ibm_runtime.options import Options
-from qiskit.providers.exceptions import QiskitBackendNotFoundError
 
 from pennylane import transform
 from pennylane.transforms.core import TransformProgram

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -557,9 +557,10 @@ class QiskitDevice2(Device):
             self._current_job = job.result(decoder=RunnerResult)
         else:  # Uses local simulator instead. After May 15th, all simulations will use this logic instead.
             self.options.execution.shots = program_inputs["shots"]
+            self.backend.set_options(shots=self.options.execution.shots)
             job = self.backend.run(
-                compiled_circuits, options=self.options
-            )  # Missing shots potentially
+                compiled_circuits,
+            )
             self._current_job = job.result()
 
         results = []

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -158,6 +158,7 @@ class TestSupportForV1andV2:
     @pytest.mark.skipif(
         Version(qiskit.__version__) < Version("1.0.0"),
         reason="Session initialization is not supported for local simulators for Qiskit version < 1.0/qiskit_ibm_runtime version < 0.22.0",
+        ## See https://docs.quantum.ibm.com/api/migration-guides/local-simulators for additional details
     )
     def test_v1_and_v2_manila(self, backend, use_primitives):
         """Test that device initializes and runs without error with V1 and V2 backends by Qiskit"""
@@ -997,6 +998,7 @@ class TestMockedExecution:
 @pytest.mark.skipif(
     Version(qiskit.__version__) < Version("1.0.0"),
     reason="Session initialization is not supported for local simulators for Qiskit version < 1.0/qiskit_ibm_runtime version < 0.22.0",
+    ## See https://docs.quantum.ibm.com/api/migration-guides/local-simulators for additional details
 )
 class TestExecution:
 

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -24,7 +24,7 @@ import qiskit
 
 import pennylane as qml
 from pennylane.tape.qscript import QuantumScript
-from qiskit_ibm_runtime import QiskitRuntimeService, Estimator
+from qiskit_ibm_runtime import Estimator
 from qiskit_ibm_runtime.options import Options
 
 # from qiskit_ibm_runtime.constants import RunnerResult

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1157,7 +1157,6 @@ class TestExecution:
 
         for data in result.metadata:
             assert isinstance(data, dict)
-            # assert list(data.keys()) == ["variance", "shots"]
         processed_result = QiskitDevice2._process_estimator_job(qs.measurements, result)
         assert isinstance(processed_result, tuple)
         assert np.allclose(processed_result, expectation, atol=0.1)

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1009,7 +1009,6 @@ class TestMockedExecution:
                 dev.execute(qs)
 
 
-@pytest.mark.usefixtures("skip_if_no_account")
 @pytest.mark.skipif(
     Version(qiskit.__version__) < Version("1.0.0"),
     reason="Session initialization is not supported for local simulators for Qiskit version < 1.0/qiskit_ibm_runtime version < 0.22.0",

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -147,12 +147,12 @@ class TestSupportForV1andV2:
         assert dev._backend == backend
 
     @pytest.mark.parametrize(
-        "backend, use_primitives",
+        "backend, use_primitives, shape",
         [
-            (FakeManila(), True),
-            (FakeManila(), False),
-            (FakeManilaV2(), True),
-            (FakeManilaV2(), False),
+            (FakeManila(), True, (1, 1024)),
+            (FakeManila(), False, (1024,)),
+            (FakeManilaV2(), True, (1, 1024)),
+            (FakeManilaV2(), False, (1024,)),
         ],
     )
     @pytest.mark.skipif(
@@ -160,7 +160,7 @@ class TestSupportForV1andV2:
         reason="Session initialization is not supported for local simulators for Qiskit version < 1.0/qiskit_ibm_runtime version < 0.22.0",
         ## See https://docs.quantum.ibm.com/api/migration-guides/local-simulators for additional details
     )
-    def test_v1_and_v2_manila(self, backend, use_primitives):
+    def test_v1_and_v2_manila(self, backend, use_primitives, shape):
         """Test that device initializes and runs without error with V1 and V2 backends by Qiskit"""
         dev = QiskitDevice2(wires=5, backend=backend, use_primitives=use_primitives)
 
@@ -170,7 +170,9 @@ class TestSupportForV1andV2:
             qml.CNOT(wires=[0, 1])
             return qml.sample(qml.PauliZ(0))
 
-        circuit(np.pi / 2)
+        res = circuit(np.pi / 2)
+
+        assert np.shape(res) == shape
         assert dev._backend == backend
 
 

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -155,6 +155,10 @@ class TestSupportForV1andV2:
             (FakeManilaV2(), False),
         ],
     )
+    @pytest.mark.skipif(
+        Version(qiskit.__version__) < Version("1.0.0"),
+        reason="Session initialization is not supported for local simulators for Qiskit version < 1.0/qiskit_ibm_runtime version < 0.22.0",
+    )
     def test_v1_and_v2_manila(self, backend, use_primitives):
         """Test that device initializes and runs without error with V1 and V2 backends by Qiskit"""
         dev = QiskitDevice2(wires=5, backend=backend, use_primitives=use_primitives)
@@ -990,6 +994,10 @@ class TestMockedExecution:
 
 
 @pytest.mark.usefixtures("skip_if_no_account")
+@pytest.mark.skipif(
+    Version(qiskit.__version__) < Version("1.0.0"),
+    reason="Session initialization is not supported for local simulators for Qiskit version < 1.0/qiskit_ibm_runtime version < 0.22.0",
+)
 class TestExecution:
 
     @pytest.mark.parametrize("wire", [0, 1])

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -155,10 +155,6 @@ class TestSupportForV1andV2:
             (FakeManilaV2(), False),
         ],
     )
-    @pytest.mark.skipif(
-        Version(qiskit.__version__) < Version("1.0.0"),
-        reason="Session initialization is different between the two versions",
-    )
     def test_v1_and_v2_manila(self, backend, use_primitives):
         """Test that device initializes and runs without error with V1 and V2 backends by Qiskit"""
         dev = QiskitDevice2(wires=5, backend=backend, use_primitives=use_primitives)

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -143,11 +143,7 @@ class TestSupportForV1andV2:
 
     @pytest.mark.parametrize(
         "backend",
-        [
-            legacy_backend,
-            backend,
-            aer_sim
-        ],
+        [legacy_backend, backend, aer_sim],
     )
     def test_v1_and_v2_mocked(self, backend):
         """Test that device initializes with no error mocked"""

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -151,23 +151,21 @@ class TestSupportForV1andV2:
         assert dev._backend == backend
 
     @pytest.mark.parametrize(
-        "backend",
-        [
-            FakeManila(),
-            FakeManilaV2(),
-        ],
+        "backend, use_primitives",
+        [(FakeManila(), [True, False]), (FakeManilaV2(), [True, False])],
     )
-    def test_v1_and_v2_manila(self, backend):
-        """Test that device initializes with no error with V1 and V2 backends by Qiskit"""
-        dev = QiskitDevice2(wires=5, backend=backend, use_primitives=True)
+    def test_v1_and_v2_manila(self, backend, use_primitives):
+        """Test that device initializes and runs without error with V1 and V2 backends by Qiskit"""
+        dev = QiskitDevice2(wires=5, backend=backend, use_primitives=use_primitives)
 
         @qml.qnode(dev)
         def circuit(x):
             qml.RX(x, wires=[0])
             qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            return qml.sample(qml.PauliZ(0))
 
-        res = circuit(np.pi / 2)
+        circuit(np.pi / 2)
+        assert dev._backend == backend
 
 
 class TestDeviceInitialization:

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1093,30 +1093,6 @@ class TestExecution:
 
         assert np.allclose(res, expectation, atol=0.3)  ## atol is high due to high variance
 
-    @pytest.mark.parametrize("wire", [0, 1, 2, 3])
-    @pytest.mark.parametrize(
-        "angle, op, multi_q_obs",
-        [
-            (
-                np.pi / 2,
-                qml.RX,
-                qml.ops.LinearCombination([1, 3], [qml.X(3) @ qml.Y(1), qml.Z(0) * 3]),
-            ),
-            (
-                np.pi,
-                qml.RX,
-                qml.ops.LinearCombination([1, 3], [qml.X(3) @ qml.Y(1), qml.Z(0) * 3])
-                - 4 * qml.X(2),
-            ),
-            (np.pi / 2, qml.RY, qml.sum(qml.PauliZ(0), qml.PauliX(1))),
-            (np.pi, qml.RY, qml.dot([2, 3], [qml.X(0), qml.Y(0)])),
-            (
-                np.pi / 2,
-                qml.RZ,
-                qml.Hamiltonian([1], [qml.X(0) @ qml.Y(2)]) - 3 * qml.Z(3) @ qml.Z(1),
-            ),
-        ],
-    )
     @pytest.mark.parametrize(
         "measurements, expectation",
         [

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -20,10 +20,11 @@ import numpy as np
 import pytest
 from semantic_version import Version
 import qiskit_ibm_runtime
+import qiskit
 
 import pennylane as qml
 from pennylane.tape.qscript import QuantumScript
-from qiskit_ibm_runtime import Estimator
+from qiskit_ibm_runtime import QiskitRuntimeService, Estimator
 from qiskit_ibm_runtime.options import Options
 
 # from qiskit_ibm_runtime.constants import RunnerResult
@@ -153,6 +154,10 @@ class TestSupportForV1andV2:
             (FakeManilaV2(), True),
             (FakeManilaV2(), False),
         ],
+    )
+    @pytest.mark.skipif(
+        Version(qiskit.__version__) < Version("1.0.0"),
+        reason="Session initialization is different between the two versions",
     )
     def test_v1_and_v2_manila(self, backend, use_primitives):
         """Test that device initializes and runs without error with V1 and V2 backends by Qiskit"""

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -27,7 +27,6 @@ from pennylane.tape.qscript import QuantumScript
 from qiskit_ibm_runtime import Estimator
 from qiskit_ibm_runtime.options import Options
 
-# from qiskit_ibm_runtime.constants import RunnerResult
 from qiskit_ibm_runtime.fake_provider import FakeManila, FakeManilaV2
 from qiskit_aer import AerSimulator
 

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -27,6 +27,7 @@ from qiskit_ibm_runtime import QiskitRuntimeService, Estimator
 from qiskit_ibm_runtime.options import Options
 from qiskit_ibm_runtime.constants import RunnerResult
 from qiskit_ibm_runtime.fake_provider import FakeManila, FakeManilaV2
+from qiskit_aer import AerSimulator
 
 # do not import Estimator (imported above) from qiskit.primitives - the identically
 # named Estimator object has a different call signature than the remote device Estimator,

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -121,10 +121,11 @@ class MockSession:
 try:
     service = QiskitRuntimeService(channel="ibm_quantum")
     backend = service.backend("ibmq_qasm_simulator")
-except Exception:
+except:
     backend = MockedBackend()
 
 legacy_backend = MockedBackendLegacy()
+aer_sim = AerSimulator()
 test_dev = QiskitDevice2(wires=5, backend=backend)
 
 
@@ -146,6 +147,7 @@ class TestSupportForV1andV2:
         [
             legacy_backend,
             backend,
+            aer_sim
         ],
     )
     def test_v1_and_v2_mocked(self, backend):
@@ -153,9 +155,6 @@ class TestSupportForV1andV2:
         dev = QiskitDevice2(wires=10, backend=backend, use_primitives=True)
         assert dev._backend == backend
 
-    @pytest.mark.skip(
-        reason="Fake backends do not have attribute _service, should address in (SC 55725)"
-    )
     @pytest.mark.parametrize(
         "backend",
         [
@@ -171,11 +170,9 @@ class TestSupportForV1andV2:
         def circuit(x):
             qml.RX(x, wires=[0])
             qml.CNOT(wires=[0, 1])
-            return qml.sample(qml.PauliZ(0))
+            return qml.expval(qml.PauliZ(0))
 
         res = circuit(np.pi / 2)
-        assert isinstance(res, np.ndarray)
-        assert np.shape(res) == (1024,)
 
 
 class TestDeviceInitialization:


### PR DESCRIPTION
As of right now, many of our tests are still using the ibmq_qasm_simulator cloud-service backend that is going to be deprecated in 2 weeks on May 15th. In response to this we are migrating from "ibmq_qasm_simulator" to a local simulator, AerSimulator, which is what Qiskit recommends for the migration.