### PR TITLE
[BugFix] Account Fetch Error

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ import qiskit
 
 import pennylane as qml
 from semantic_version import Version
-from qiskit_ibm_provider import IBMProvider, IBMProviderValueError
+from qiskit_ibm_provider import IBMProvider
 from pennylane_qiskit import AerDevice, BasicAerDevice, BasicSimulatorDevice
 
 # pylint: disable=protected-access, unused-argument, redefined-outer-name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def skip_if_no_account():
     t = os.getenv("IBMQX_TOKEN", None)
     try:
         IBMProvider(token=t)
-    except IBMProviderValueError:
+    except:  # pylint: disable=broad-except, bare-except
         missing = "token" if t else "account"
         pytest.skip(f"Skipping test, no IBMQ {missing} available")
 


### PR DESCRIPTION
There seems to be an unwarranted behaviour creeping in due to adding error types in the `skip_if_no_account` test for `conftest.py`. This PR rolls back that particular change. 
This hopefully fixes the workflow failures in this [PR](https://github.com/PennyLaneAI/pennylane-qiskit/pull/517). 