### PR TITLE
Use old _execute_runtime_service for observables that are not compatible with SPO representation

### DIFF
--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -495,9 +495,8 @@ class QiskitDevice2(Device):
                             f"Setting shot vector {circ.shots.shot_vector} is not supported for {self.name}."
                             f"The circuit will be run once with {circ.shots.total_shots} shots instead."
                         )
-                    if (
-                        isinstance(circ.measurements[0], (ExpectationMP, VarianceMP))
-                        and circ.measurements[0].obs.pauli_rep
+                    if isinstance(circ.measurements[0], (ExpectationMP, VarianceMP)) and all(
+                        mp.obs.pauli_rep for mp in circ.measurements
                     ):
                         execute_fn = self._execute_estimator
                     elif isinstance(circ.measurements[0], ProbabilityMP):
@@ -602,8 +601,6 @@ class QiskitDevice2(Device):
         # for expectation value and variance on the same observable, but spending time on
         # that right now feels excessive
 
-        # ToDo: need to sort differently for cases where the observable is not
-        # compatible with a SparsePauliOp representation
         pauli_observables = [mp_to_pauli(mp, self.num_wires) for mp in circuit.measurements]
         result = estimator.run([qcirc] * len(pauli_observables), pauli_observables).result()
         self._current_job = result

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -558,6 +558,11 @@ class QiskitDevice2(Device):
 
         results = []
 
+        ### ToDo: ensure the measurements in circuit.measurements commute
+        ### Need to wait to implement transforms such as split non-commute, ham expand, etc.
+        ### [SC-62047]
+        ### Can't raise a warning/error because if we could figure out that the measurements
+        ### did not commute then we could just split it instead of raising a warning/error.
         for index, circuit in enumerate(circuits):
             self._samples = self.generate_samples(index)
             res = [

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -516,6 +516,13 @@ class QiskitDevice2(Device):
         # update kwargs in case Options has been modified since last execution
         self._update_kwargs()
 
+        if self._use_primitives:
+            warnings.warn(
+                "`use_primitives` is set as True but the circuit will be ran without using "
+                "primitives. This is because an observable e.g. `qml.expval(qml.Hadamard(0))`"
+                " does not have a `pauli_rep`."
+            )
+
         # in case a single circuit is passed
         if isinstance(circuits, QuantumScript):
             circuits = [circuits]

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -413,7 +413,7 @@ class QiskitDevice2(Device):
         # missing: split non-commuting, sum_expand, etc. [SC-62047]
 
         if self._use_primitives:
-            transform_program.add_transform(split_measurement_types)
+            transform_program.add_transform(split_execution_types)
 
         return transform_program, config
 

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -507,7 +507,7 @@ class QiskitDevice2(Device):
                         )
                     if (
                         isinstance(circ.measurements[0], (ExpectationMP, VarianceMP))
-                        and circ.measurements[0].obs.pauli_rep
+                        and getattr(circ.measurements[0], "pauli_rep", None)
                     ):
                         execute_fn = self._execute_estimator
                     elif isinstance(circ.measurements[0], ProbabilityMP):

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -497,7 +497,7 @@ class QiskitDevice2(Device):
                         )
                     if (
                         isinstance(circ.measurements[0], (ExpectationMP, VarianceMP))
-                        and circ.measurements.obs.pauli_rep
+                        and circ.measurements[0].obs.pauli_rep
                     ):
                         execute_fn = self._execute_estimator
                     elif isinstance(circ.measurements[0], ProbabilityMP):

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -147,6 +147,7 @@ def split_execution_types(
                     "and will be run without using the Estimator primitive. Instead, "
                     "the standard backend.run function will be used."
                 )
+                no_prim.append((mp, i))
         elif isinstance(mp, ProbabilityMP):
             sampler.append((mp, i))
         else:

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -516,8 +516,6 @@ class QiskitDevice2(Device):
         # update kwargs in case Options has been modified since last execution
         self._update_kwargs()
 
-        print(self._use_primitives)
-
         if self._use_primitives:
             warnings.warn(
                 "`use_primitives` is set as True but the circuit will be ran without using "

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -505,9 +505,8 @@ class QiskitDevice2(Device):
                             f"Setting shot vector {circ.shots.shot_vector} is not supported for {self.name}."
                             f"The circuit will be run once with {circ.shots.total_shots} shots instead."
                         )
-                    if (
-                        isinstance(circ.measurements[0], (ExpectationMP, VarianceMP))
-                        and getattr(circ.measurements[0], "pauli_rep", None)
+                    if isinstance(circ.measurements[0], (ExpectationMP, VarianceMP)) and getattr(
+                        circ.measurements[0], "pauli_rep", None
                     ):
                         execute_fn = self._execute_estimator
                     elif isinstance(circ.measurements[0], ProbabilityMP):

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -495,7 +495,10 @@ class QiskitDevice2(Device):
                             f"Setting shot vector {circ.shots.shot_vector} is not supported for {self.name}."
                             f"The circuit will be run once with {circ.shots.total_shots} shots instead."
                         )
-                    if isinstance(circ.measurements[0], (ExpectationMP, VarianceMP)):
+                    if (
+                        isinstance(circ.measurements[0], (ExpectationMP, VarianceMP))
+                        and circ.measurements.obs.pauli_rep
+                    ):
                         execute_fn = self._execute_estimator
                     elif isinstance(circ.measurements[0], ProbabilityMP):
                         execute_fn = self._execute_sampler

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -506,7 +506,7 @@ class QiskitDevice2(Device):
                             f"The circuit will be run once with {circ.shots.total_shots} shots instead."
                         )
                     if isinstance(circ.measurements[0], (ExpectationMP, VarianceMP)) and getattr(
-                        circ.measurements[0], "pauli_rep", None
+                        circ.measurements[0].obs, "pauli_rep", None
                     ):
                         execute_fn = self._execute_estimator
                     elif isinstance(circ.measurements[0], ProbabilityMP):

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -138,8 +138,15 @@ def split_execution_types(
     no_prim = []
 
     for i, mp in enumerate(tape.measurements):
-        if isinstance(mp, (ExpectationMP, VarianceMP)) and mp.obs.pauli_rep:
-            estimator.append((mp, i))
+        if isinstance(mp, (ExpectationMP, VarianceMP)):
+            if mp.obs.pauli_rep:
+                estimator.append((mp, i))
+            else:
+                warnings.warn(
+                    f"The observable measured {mp.obs} does not have a `pauli_rep` "
+                    "and will be run without using the Estimator primitive. Instead, "
+                    "the standard backend.run function will be used."
+                )
         elif isinstance(mp, ProbabilityMP):
             sampler.append((mp, i))
         else:
@@ -518,13 +525,6 @@ class QiskitDevice2(Device):
         """Execution using old runtime_service (can't use runtime sessions)"""
         # update kwargs in case Options has been modified since last execution
         self._update_kwargs()
-
-        if self._use_primitives:
-            warnings.warn(
-                "`use_primitives` is set as True but the circuit will be ran without using "
-                "primitives. This is because an observable e.g. `qml.expval(qml.Hadamard(0))`"
-                " does not have a `pauli_rep`."
-            )
 
         # in case a single circuit is passed
         if isinstance(circuits, QuantumScript):

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -516,6 +516,8 @@ class QiskitDevice2(Device):
         # update kwargs in case Options has been modified since last execution
         self._update_kwargs()
 
+        print(self._use_primitives)
+
         if self._use_primitives:
             warnings.warn(
                 "`use_primitives` is set as True but the circuit will be ran without using "

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -127,7 +127,7 @@ def accepted_sample_measurement(m: qml.measurements.MeasurementProcess) -> bool:
 def split_execution_types(
     tape: qml.tape.QuantumTape,
 ) -> (Sequence[qml.tape.QuantumTape], Callable):
-    """Split into separate tapes based on measurement type. However, for `expval` and `var`
+    """Split into separate tapes based on measurement type. However, for ``expval`` and ``var``
     measurements, if the measured observable does not have a `pauli_rep`, it is split as a
     separate tape and will use the standard backend.run function. Counts will use the
     Qiskit Sampler, ExpectationValue and Variance will use the Estimator, and other

--- a/pennylane_qiskit/qiskit_device2.py
+++ b/pennylane_qiskit/qiskit_device2.py
@@ -128,7 +128,7 @@ def split_execution_types(
     tape: qml.tape.QuantumTape,
 ) -> (Sequence[qml.tape.QuantumTape], Callable):
     """Split into separate tapes based on measurement type. However, for ``expval`` and ``var``
-    measurements, if the measured observable does not have a `pauli_rep`, it is split as a
+    measurements, if the measured observable does not have a ``pauli_rep``, it is split as a
     separate tape and will use the standard backend.run function. Counts will use the
     Qiskit Sampler, ExpectationValue and Variance will use the Estimator, and other
     strictly sample-based measurements will use the standard backend.run function"""

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -66,14 +66,12 @@ class MockedBackend(BackendV2):
         self.name = name
         self._target = Mock()
         self._target.num_qubits = num_qubits
+        self._coupling_map = {}
 
     def set_options(self, noise_model):
         self.options.noise_model = noise_model
 
     def _default_options(self):
-        return {}
-    
-    def _coupling_map(self):
         return {}
 
     def max_circuits(self):

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1309,7 +1309,7 @@ class TestExecution:
             [qml.expval(qml.Hadamard(0))],
             [qml.expval(qml.Hadamard(0)), qml.expval(qml.PauliX(1))],
             [qml.expval(qml.PauliZ(0)), qml.expval(qml.Hadamard(1))],
-            # [qml.expval(qml.PauliZ(0)), qml.expval(qml.Hadamard(0))] fails due to a bug in _execute_runtime_service.
+            # [qml.expval(qml.PauliZ(0)), qml.expval(qml.Hadamard(0))] fails due to not splitting non-commuting transforms. Refer to [SC-62047]
         ],
     )
     def test_unsupported_observable_gives_accurate_answer(self, measurements):

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1294,8 +1294,9 @@ class TestExecution:
     )
     @pytest.mark.filterwarnings("ignore::UserWarning")
     def test_unsupported_observable_gives_accurate_answer(self, mocker, observable):
-        """Test that the device uses _execute_runtime_service and _execute_estimator and provides
-        an accurate answer for measurements that contain observables that don't have a pauli_rep."""
+        """Test that the device uses _execute_runtime_service and _execute_estimator appropriately
+        and provides an accurate answer for measurements with observables that don't have a pauli_rep.
+        """
 
         dev = QiskitDevice2(wires=5, backend=backend, use_primitives=True)
 
@@ -1326,9 +1327,9 @@ class TestExecution:
 
         assert np.allclose(res, pl_res, atol=0.1)
 
-    def test_warning_for_execute_runtime_service(self):
-        """Test that a warning is raised when device uses _execute_runtime_service
-        despite use_primitives being set to True"""
+    def test_warning_for_split_execution_types_when_observable_no_pauli(self):
+        """Test that a warning is raised when device is passed a measurement on
+        an observable that does not have a pauli_rep."""
 
         dev = QiskitDevice2(
             wires=5,

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1028,6 +1028,7 @@ class TestMockedExecution:
         sampler_execute.assert_not_called()
         estimator_execute.assert_not_called()
 
+
 @pytest.mark.usefixtures("skip_if_no_account")
 class TestExecution:
     @pytest.mark.parametrize("wire", [0, 1])

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -995,6 +995,24 @@ class TestMockedExecution:
             ):
                 dev.execute(qs)
 
+    def test_warning_for_execute_runtime_service(self):
+        """Test that a warning is raised when device uses _execute_runtime_service
+        despite use_primitives being set to True"""
+
+        dev = QiskitDevice2(wires=5, backend=backend, use_primitives=True)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.X(0)
+            qml.Hadamard(0)
+            return qml.expval(qml.Hadamard(0))
+
+        with pytest.warns(
+            UserWarning,
+            match="The observable measured",
+        ):
+            circuit()
+
 
 @pytest.mark.usefixtures("skip_if_no_account")
 class TestExecution:
@@ -1312,21 +1330,3 @@ class TestExecution:
         sampler_execute.assert_not_called()
 
         assert np.allclose(res, pl_res, atol=0.1)
-
-    def test_warning_for_execute_runtime_service(self):
-        """Test that a warning is raised when device uses _execute_runtime_service
-        despite use_primitives being set to True"""
-
-        dev = QiskitDevice2(wires=5, backend=backend, use_primitives=True)
-
-        @qml.qnode(dev)
-        def circuit():
-            qml.X(0)
-            qml.Hadamard(0)
-            return qml.expval(qml.Hadamard(0))
-
-        with pytest.warns(
-            UserWarning,
-            match="The observable measured",
-        ):
-            circuit()

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1000,7 +1000,9 @@ class TestMockedExecution:
         """Test that a warning is raised when device uses _execute_runtime_service
         despite use_primitives being set to True"""
 
-        dev = QiskitDevice2(wires=5, backend=backend, use_primitives=True)
+        dev = QiskitDevice2(
+            wires=5, backend=backend, use_primitives=True, session=MockSession(backend)
+        )
 
         @qml.qnode(dev)
         def circuit():

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -72,6 +72,9 @@ class MockedBackend(BackendV2):
 
     def _default_options(self):
         return {}
+    
+    def _coupling_map(self):
+        return {}
 
     def max_circuits(self):
         return 10

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1293,7 +1293,7 @@ class TestExecution:
         ],
     )
     @pytest.mark.filterwarnings("ignore::UserWarning")
-    def test_unsupported_observable_gives_accurate_answer(self, mocker, observable):
+    def test_no_pauli_observable_gives_accurate_answer(self, mocker, observable):
         """Test that the device uses _execute_runtime_service and _execute_estimator appropriately
         and provides an accurate answer for measurements with observables that don't have a pauli_rep.
         """

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1028,24 +1028,6 @@ class TestMockedExecution:
         sampler_execute.assert_not_called()
         estimator_execute.assert_not_called()
 
-    def test_mocked_warning_for_execute_runtime_service(self):
-        """Test that a warning is raised when device uses _execute_runtime_service
-        despite use_primitives being set to True"""
-
-        dev = QiskitDevice2(wires=5, backend=backend, use_primitives=True)
-
-        qs = QuantumScript(
-            measurements=[qml.expval(qml.Hadamard(0))],
-            shots=[1],
-        )
-
-        with pytest.warns(
-            UserWarning,
-            match="`use_primitives` is set as True",
-        ):
-            dev.execute(qs)
-
-
 @pytest.mark.usefixtures("skip_if_no_account")
 class TestExecution:
     @pytest.mark.parametrize("wire", [0, 1])

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -995,39 +995,6 @@ class TestMockedExecution:
             ):
                 dev.execute(qs)
 
-    @pytest.mark.parametrize(
-        "measurements",
-        [
-            [qml.expval(qml.Hadamard(0))],
-            [qml.expval(qml.Hadamard(0)), qml.expval(qml.PauliX(1))],
-            [qml.expval(qml.PauliZ(0)), qml.expval(qml.Hadamard(1))],
-            [qml.expval(qml.PauliZ(0)), qml.expval(qml.Hadamard(0))],
-        ],
-    )
-    def test_unsupported_observable_uses_execute_runtime_service(self, mocker, measurements):
-        """Test that a device uses _execute_runtime_service instead of _execute_estimator
-        when measurements contains an observable that does not have a pauli_rep"""
-
-        dev = QiskitDevice2(
-            wires=5, backend=backend, use_primitives=True, session=MockSession(backend)
-        )
-        qs = QuantumScript(
-            measurements=measurements,
-            shots=[10],
-        )
-        with patch.object(dev, "_execute_runtime_service", return_value="runtime_execute_res"):
-            with patch.object(dev, "_execute_sampler", return_value="sampler_execute_res"):
-                with patch.object(dev, "_execute_estimator", return_value="estimator_execute_res"):
-                    runtime_service_execute = mocker.spy(dev, "_execute_runtime_service")
-                    sampler_execute = mocker.spy(dev, "_execute_sampler")
-                    estimator_execute = mocker.spy(dev, "_execute_estimator")
-
-                    dev.execute(qs)
-
-        runtime_service_execute.assert_called_once()
-        sampler_execute.assert_not_called()
-        estimator_execute.assert_not_called()
-
 
 @pytest.mark.usefixtures("skip_if_no_account")
 class TestExecution:
@@ -1315,7 +1282,7 @@ class TestExecution:
     @pytest.mark.filterwarnings("ignore::UserWarning")
     def test_unsupported_observable_gives_accurate_answer(self, mocker, observable):
         """Test that the device uses _execute_runtime_service and _execute_estimator and provides
-        an accurate answer for measurements that contain observables that don't a pauli_rep."""
+        an accurate answer for measurements that contain observables that don't have a pauli_rep."""
 
         dev = QiskitDevice2(wires=5, backend=backend, use_primitives=True)
 

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1295,3 +1295,23 @@ class TestExecution:
         # Should reset to device shots if circuit ran again without shots defined
         circuit()
         assert dev._current_job.metadata[0]["shots"] == 2
+
+    def test_unsupported_observable_gives_accurate_answer(self, mocker):
+        """Test that a device that has an unsupported observables uses _execute_runtime_service and provides an accurate answer"""
+
+        dev = QiskitDevice2(
+            wires=5, backend=backend, use_primitives=True, session=MockSession(backend)
+        )
+
+        pl_dev = qml.device("default.qubit", wires=5)
+
+        qs = QuantumScript(
+            measurements=[
+                qml.expval(qml.Hadamard(0)),
+            ],
+            shots=[10000],
+        )
+        res = dev.execute(qs)
+        pl_res = pl_dev.execute(qs)
+
+        assert np.allclose(res, pl_res, atol=0.05)

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1289,7 +1289,7 @@ class TestExecution:
         [
             [qml.Hadamard(0), qml.PauliX(1)],
             [qml.PauliZ(0), qml.Hadamard(1)],
-            # [qml.expval(qml.PauliZ(0)), qml.expval(qml.Hadamard(0))] fails due to not splitting non-commuting transforms. Refer to [SC-62047]
+            [qml.PauliZ(0), qml.Hadamard(0)],
         ],
     )
     @pytest.mark.filterwarnings("ignore::UserWarning")

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1324,7 +1324,13 @@ class TestExecution:
             measurements=measurements,
             shots=[10000],
         )
-        res = dev.execute(qs)
+
+        with pytest.warns(
+            UserWarning,
+            match="`use_primitives` is set",
+        ):
+            res = dev.execute(qs)
+
         pl_res = pl_dev.execute(qs)
 
         assert np.allclose(res, pl_res, atol=0.05)

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1309,7 +1309,7 @@ class TestExecution:
             [qml.expval(qml.Hadamard(0))],
             [qml.expval(qml.Hadamard(0)), qml.expval(qml.PauliX(1))],
             [qml.expval(qml.PauliZ(0)), qml.expval(qml.Hadamard(1))],
-            # [qml.expval(qml.PauliZ(0)), qml.expval(qml.Hadamard(0))] This should not fail, but fails due to the way we diagonalize right now. For more information, refer to [SC-62047].
+            # [qml.expval(qml.PauliZ(0)), qml.expval(qml.Hadamard(0))] fails due to a bug in _execute_runtime_service.
         ],
     )
     def test_unsupported_observable_gives_accurate_answer(self, measurements):


### PR DESCRIPTION
Although most observables supported by PL do have a pauli rep (therefore an SPO rep), there are certain observables such as Hadamard that do not have a pauli_rep. This is a problem because we can't translate it to an SPO rep to be used with the Estimator primitive. This PR seeks to amend this by having those circuits sent to the old _execute_runtime_service instead, where we can avoid this problem.