### PR TITLE
Example added `BasicSim` docs that shows default `shots`

### DIFF
--- a/doc/devices/basicsim.rst
+++ b/doc/devices/basicsim.rst
@@ -14,6 +14,21 @@ that can be accessed in this plugin through:
 
 This device uses the Qiskit ``BasicSimulator`` backend from the
 `basic_provider <https://docs.quantum.ibm.com/api/qiskit/providers_basic_provider>`_ module in Qiskit.
+In Qiskit, ``BasicSimulator`` uses ``shots=1024`` by default. As such, the same convention has been applied
+to `'qiskit.basicsim'` in PennyLane. 
+
+.. code-block:: python
+
+    @qml.qnode(dev)
+    def circuit():
+        qml.Hadamard(0)
+        qml.Hadamard(1)
+        return qml.count(wires=1)
+
+.. code-block:: pycon
+    
+    >>> circuit()
+    {'0': tensor(520, requires_grad=True), '1': tensor(504, requires_grad=True)} 
 
 .. note::
 


### PR DESCRIPTION
In Qiskit, when you use this device / backend you’re hard-corded at `shots=1024`. I assume Qiskit users are aware of this. However, when I used this device in PennyLane, I ran this circuit not expecting it to work because I didn’t specify shots. 

```
pl_qfunc = qml.from_qiskit(qc, measurements=[qml.classical_shadow(wires=range(n))])
pl_circuit = qml.QNode(pl_qfunc, device=qml.device("qiskit.basicsim", wires=n))
pl_circuit()
```

I had to go digging into the source code to figure out what was going on. As a PennyLane user, I found this confusing (does that matter? lol). Anyway, a simple addition to the docs seems fine to me.