### PR TITLE
add qasm measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Improvements 🛠
 
+* Updated `load_qasm` to take the optional kwarg `measurements` which get performed at the end of the loaded circuit and `load_qasm` can now detect mid-circuit measurements from `qasm`.
+[(#555)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/555)
+
 ### Breaking changes 💔
 
 ### Deprecations 👋
@@ -15,6 +18,8 @@
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Mashhood Khan
 
 ---
 # Release 0.36.0

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -20,6 +20,7 @@ import warnings
 from functools import partial, reduce
 
 import numpy as np
+import qiskit.qasm2
 from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter, ParameterExpression, ParameterVector
 from qiskit.circuit import Measure, Barrier, ControlFlowOp, Clbit
@@ -584,14 +585,17 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
     return _function
 
 
-def load_qasm(qasm_string: str):
+def load_qasm(qasm_string: str, measurements=None):
     """Loads a PennyLane template from a QASM string.
     Args:
         qasm_string (str): the name of the QASM string
+        measurements (None | pennylane.measurements.MeasurementProcess | list[pennylane.measurements.MeasurementProcess]):
+            the PennyLane `measurements <https://docs.pennylane.ai/en/stable/introduction/measurements.html>`_
+            that override the terminal measurements that may be present in the input circuit
     Returns:
         function: the new PennyLane template
     """
-    return load(QuantumCircuit.from_qasm_str(qasm_string), measurements=[])
+    return load(qiskit.qasm2.loads(qasm_string), measurements=measurements)
 
 
 def load_qasm_from_file(file: str):

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -587,11 +587,13 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
 
 def load_qasm(qasm_string: str, measurements=None):
     """Loads a PennyLane template from a QASM string.
+
     Args:
         qasm_string (str): the name of the QASM string
         measurements (None | pennylane.measurements.MeasurementProcess | list[pennylane.measurements.MeasurementProcess]):
             the PennyLane `measurements <https://docs.pennylane.ai/en/stable/introduction/measurements.html>`_
             that override the terminal measurements that may be present in the input circuit
+
     Returns:
         function: the new PennyLane template
     """

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1185,11 +1185,7 @@ class TestConverterQasm:
     def test_qasm_measure(self):
         """Tests that measurements specified as an argument are added to the converted circuit."""
         qasm_string = (
-            'include "qelib1.inc";'
-            "qreg q[2];"
-            "creg c[2];"
-            "h q[0];"
-            "cx q[0], q[1];"
+            'include "qelib1.inc";' + "qreg q[2];" + "creg c[2];" + "h q[0];" + "cx q[0], q[1];"
         )
         dev = qml.device("default.qubit")
         measurements = [qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))]

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1182,7 +1182,13 @@ class TestConverterQasm:
 
     def test_qasm_measure(self):
         """Tests that measurements specified as an argument are added to the converted circuit."""
-        qasm_string = 'include "qelib1.inc";' "qreg q[2];" "creg c[2];" "h q[0];" "cx q[0], q[1];"
+        qasm_string = (
+            'include "qelib1.inc";'
+            "qreg q[2];"
+            "creg c[2];"
+            "h q[0];"
+            "cx q[0], q[1];"
+        )
         dev = qml.device("default.qubit")
         measurements = [qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))]
         loaded_circuit = load_qasm(qasm_string, measurements=measurements)
@@ -1218,7 +1224,7 @@ class TestConverterQasm:
         # loaded circuit
         @qml.qnode(dev)
         def quantum_circuit1():
-            mid_measure, m0, m1 = loaded_circuit()
+            mid_measure, _, m1 = loaded_circuit()
             qml.cond(mid_measure == 0, qml.RX)(np.pi / 2, 0)
             return qml.expval(mid_measure), qml.expval(m1)
 
@@ -1229,7 +1235,7 @@ class TestConverterQasm:
             mid_measure = qml.measure(0)
             qml.RZ(0.24, 0)
             qml.CNOT([0, 1])
-            m0 = qml.measure([0])
+            qml.measure([0])
             m1 = qml.measure([1])
             qml.cond(mid_measure == 0, qml.RX)(np.pi / 2, 0)
             return qml.expval(mid_measure), qml.expval(m1)


### PR DESCRIPTION
For https://github.com/PennyLaneAI/pennylane/issues/5646.
Updated `load_qasm` to take optional measurements as an argument and added the ability for it to make mid-circuit measurements.
Tests added in `tests/test_converter.py`.