### PR TITLE
Fix asserts for `Conditionals` for controlled flow operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Improvements 🛠
 
+* Improvements have been made to load circuits with `SwitchCaseOp` gates with default case.
+  [(#514)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/514)
+
 ### Breaking changes 💔
 
 ### Deprecations 👋
@@ -15,6 +18,8 @@
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Utkarsh Azad
 
 ---
 # Release 0.36.0

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -867,11 +867,15 @@ def _process_switch_condition(condition, mid_circ_regs):
         if all(clbit in mid_circ_regs for clbit in clbits):
             # Build an integer representation for each switch case
             meas_pl_op = sum(2**idx * mid_circ_regs[clbit] for idx, clbit in enumerate(clbits))
+            # Non Expr-based condition can have 2**#clbits Boolean outputs: 0, ..., 2**#clbits - 1
+            # If all of them are already covered in the given cases, skip the default case.
             use_switch_default = bool(set(condition[1]) ^ set(range(2 ** len(clbits))))
 
     # if the target is an Expr
     else:
         meas_pl_op = _expr_evaluation(condition[0], mid_circ_regs)
+        # Expr-based condition can have two Boolean outputs: 0 and 1
+        # If both of them are already covered in the given cases, skip the default case.
         use_switch_default = bool(set(condition[1]) ^ {0, 1})
 
     meas_pl_ops = []

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -867,7 +867,7 @@ def _process_switch_condition(condition, mid_circ_regs):
         if all(clbit in mid_circ_regs for clbit in clbits):
             # Build an integer representation for each switch case
             meas_pl_op = sum(2**idx * mid_circ_regs[clbit] for idx, clbit in enumerate(clbits))
-            # Non Expr-based condition can have 2**#clbits Boolean outputs: 0, ..., 2**#clbits - 1
+            # Non Expr-based condition can have 2**#clbits outputs: 0, ..., 2**#clbits - 1
             # If all of them are already covered in the given cases, skip the default case.
             use_switch_default = bool(set(condition[1]) ^ set(range(2 ** len(clbits))))
 

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -856,6 +856,7 @@ def _process_switch_condition(condition, mid_circ_regs):
     Returns:
         meas_pl_ops: list of corresponding mid-circuit measurements to be used in ``qml.cond``
     """
+    use_switch_default = True
     # if the target is not an Expr
     if not isinstance(condition[0], expr.Expr):
         # Prepare the classical bits used for the condition
@@ -866,17 +867,19 @@ def _process_switch_condition(condition, mid_circ_regs):
         if all(clbit in mid_circ_regs for clbit in clbits):
             # Build an integer representation for each switch case
             meas_pl_op = sum(2**idx * mid_circ_regs[clbit] for idx, clbit in enumerate(clbits))
+            use_switch_default = bool(set(condition[1]) ^ set(range(2 ** len(clbits))))
 
     # if the target is an Expr
     else:
         meas_pl_op = _expr_evaluation(condition[0], mid_circ_regs)
+        use_switch_default = bool(set(condition[1]) ^ {0, 1})
 
     meas_pl_ops = []
     if meas_pl_op is not None:
         # Add a measurement for each of the switch cases
         meas_pl_ops.extend([meas_pl_op == clval for clval in condition[1]])
         # If we have default case, add an additional measurement for it
-        if condition[2] == "SwitchDefault":
+        if condition[2] == "SwitchDefault" and use_switch_default:
             meas_pl_ops.append(
                 reduce(
                     lambda m0, m1: m0 & m1,

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -28,6 +28,7 @@ from qiskit.quantum_info import SparsePauliOp
 
 import pennylane as qml
 from pennylane import numpy as np
+from pennylane.measurements import MidMeasureMP
 from pennylane.wires import Wires
 from pennylane_qiskit.converter import (
     load,
@@ -38,6 +39,7 @@ from pennylane_qiskit.converter import (
     _format_params_dict,
     _check_parameter_bound,
 )
+
 
 # pylint: disable=protected-access, unused-argument, too-many-arguments
 
@@ -1650,16 +1652,16 @@ class TestControlOpIntegration:
             return [qml.expval(m) for m in [m0, m1, qml.measure(0), qml.measure(1), qml.measure(2)]]
 
         assert loaded_qiskit_circuit() == built_pl_circuit()
-        assert all(
-            (
-                op1 == op2
-                if not isinstance(op1, qml.measurements.MidMeasureMP)
-                else op1.wires == op2.wires
-            )
-            for op1, op2 in zip(
-                loaded_qiskit_circuit.tape.operations, built_pl_circuit.tape.operations
-            )
-        )
+        assert len(loaded_qiskit_circuit.tape.operations) == len(built_pl_circuit.tape.operations)
+        for op1, op2 in zip(
+            loaded_qiskit_circuit.tape.operations, built_pl_circuit.tape.operations
+        ):
+            if isinstance(op1, MidMeasureMP) or isinstance(op2, MidMeasureMP):
+                assert op1.wires == op2.wires
+            elif isinstance(op1, qml.ops.Conditional) or isinstance(op2, qml.ops.Conditional):
+                assert qml.equal(op1.base, op2.base) and op1.meas_val.wires == op2.meas_val.wires
+            else:
+                assert qml.equal(op1, op2)
 
     # pylint: disable=too-many-statements
     @pytest.mark.parametrize("cond_type", ["clbit", "clreg", "expr1", "expr2", "expr3"])
@@ -1731,22 +1733,27 @@ class TestControlOpIntegration:
                 qml.cond(mint1 >= 2, qml.PauliX)([0])
                 qml.cond(mint1 < 2, qml.PauliX)([1])
             elif cond_type == "expr3":
-                qml.cond(mint1 == mint2, qml.PauliX)([0])
-                qml.cond(mint1 != mint2, qml.PauliX)([1])
+                qml.cond(mint1 <= mint2, qml.PauliX)([0])
+                qml.cond(mint1 > mint2, qml.PauliX)([1])
+
+            qml.Barrier([0, 1, 2, 3, 4])
 
             return qml.expval(qml.PauliZ(0) @ qml.PauliY(1))
 
         assert loaded_qiskit_circuit() == built_pl_circuit()
-        assert all(
-            (
-                op1 == op2
-                if not isinstance(op1, qml.measurements.MidMeasureMP)
-                else op1.wires == op2.wires
-            )
-            for op1, op2 in zip(
-                loaded_qiskit_circuit.tape.operations, built_pl_circuit.tape.operations
-            )
-        )
+
+        assert len(loaded_qiskit_circuit.tape.operations) == len(built_pl_circuit.tape.operations)
+        for op1, op2 in zip(
+            loaded_qiskit_circuit.tape.operations, built_pl_circuit.tape.operations
+        ):
+            if isinstance(op1, MidMeasureMP) or isinstance(op2, MidMeasureMP):
+                assert op1.wires == op2.wires
+            elif isinstance(op1, qml.ops.Conditional) or isinstance(op2, qml.ops.Conditional):
+                assert qml.equal(op1.base, op2.base) and sorted(op1.meas_val.wires) == sorted(
+                    op2.meas_val.wires
+                )
+            else:
+                assert qml.equal(op1, op2)
 
     def test_warning_for_non_accessible_classical_info(self):
         """Tests a UserWarning is raised if we do not have access to classical info."""
@@ -1831,14 +1838,16 @@ class TestControlOpIntegration:
             return qml.expval(qml.PauliZ(0))
 
         assert qk_circuit() == pl_circuit()
-        assert all(
-            (
-                op1 == op2
-                if not isinstance(op1, qml.measurements.MidMeasureMP)
-                else op1.wires == op2.wires
-            )
-            for op1, op2 in zip(qk_circuit.tape.operations, pl_circuit.tape.operations)
-        )
+        assert len(qk_circuit.tape.operations) == len(pl_circuit.tape.operations)
+        for op1, op2 in zip(qk_circuit.tape.operations, pl_circuit.tape.operations):
+            if isinstance(op1, MidMeasureMP) or isinstance(op2, MidMeasureMP):
+                assert op1.wires == op2.wires
+            elif isinstance(op1, qml.ops.Conditional) or isinstance(op2, qml.ops.Conditional):
+                assert qml.equal(op1.base, op2.base) and sorted(op1.meas_val.wires) == sorted(
+                    op2.meas_val.wires
+                )
+            else:
+                assert qml.equal(op1, op2)
 
     def test_measurement_are_not_discriminated(self):
         """Test the all measurements are considered mid-circuit measurements when no terminal measurements are given"""

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -174,15 +174,15 @@ class TestAnalyticWarningHWSimulator:
         with pytest.warns(UserWarning) as record:
             dev = qml.device("qiskit.aer", backend="aer_simulator", wires=2, shots=None)
 
-        # check that only one warning was raised
-        assert len(record) == 1
-        # check that the message matches
         assert (
-            record[0].message.args[0] == "The analytic calculation of "
+            record[1].message.args[0] == "The analytic calculation of "
             "expectations, variances and probabilities is only supported on "
             f"statevector backends, not on the {dev.backend.name}. Such statistics obtained from this "
             "device are estimates based on samples."
         )
+
+        # Two warnings are being raised: one about analytic calculations and another about deprecation.
+        assert len(record) == 2
 
     @pytest.mark.parametrize("method", ["unitary", "statevector"])
     def test_no_warning_raised_for_software_backend_analytic_expval(
@@ -193,8 +193,10 @@ class TestAnalyticWarningHWSimulator:
 
         _ = qml.device("qiskit.aer", backend="aer_simulator", method=method, wires=2, shots=None)
 
-        # check that no warnings were raised
-        assert len(recwarn) == 0
+        # These simulators are being deprecated. Warning is raised in Qiskit 1.0
+        # Migrate to AerSimulator with AerSimulator(method=method) and append
+        # run circuits with the `save_state` instruction.
+        assert len(recwarn) == 1
 
 
 class TestAerBackendOptions:

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -15,9 +15,12 @@ r"""
 This module contains tests qiskit devices for PennyLane IBMQ devices.
 """
 from unittest.mock import Mock
+from packaging.version import Version
+
 import numpy as np
 import pytest
 
+import qiskit as qk
 from qiskit_aer import noise
 from qiskit.providers import BackendV1, BackendV2
 from qiskit_ibm_runtime.fake_provider import FakeManila, FakeManilaV2
@@ -175,14 +178,14 @@ class TestAnalyticWarningHWSimulator:
             dev = qml.device("qiskit.aer", backend="aer_simulator", wires=2, shots=None)
 
         assert (
-            record[1].message.args[0] == "The analytic calculation of "
+            record[-1].message.args[0] == "The analytic calculation of "
             "expectations, variances and probabilities is only supported on "
             f"statevector backends, not on the {dev.backend.name}. Such statistics obtained from this "
             "device are estimates based on samples."
         )
 
         # Two warnings are being raised: one about analytic calculations and another about deprecation.
-        assert len(record) == 2
+        assert len(record) == 2 if Version("1.0") < Version(qk.__version__) else 1
 
     @pytest.mark.parametrize("method", ["unitary", "statevector"])
     def test_no_warning_raised_for_software_backend_analytic_expval(
@@ -196,7 +199,7 @@ class TestAnalyticWarningHWSimulator:
         # These simulators are being deprecated. Warning is raised in Qiskit 1.0
         # Migrate to AerSimulator with AerSimulator(method=method) and append
         # run circuits with the `save_state` instruction.
-        assert len(recwarn) == 1
+        assert len(recwarn) == 1 if Version("1.0") < Version(qk.__version__) else 0
 
 
 class TestAerBackendOptions:

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -185,7 +185,7 @@ class TestAnalyticWarningHWSimulator:
         )
 
         # Two warnings are being raised: one about analytic calculations and another about deprecation.
-        assert len(record) == 2 if Version("1.0") < Version(qk.__version__) else 1
+        assert len(record) == (2 if Version("1.0") < Version(qk.__version__) else 1)
 
     @pytest.mark.parametrize("method", ["unitary", "statevector"])
     def test_no_warning_raised_for_software_backend_analytic_expval(
@@ -199,7 +199,7 @@ class TestAnalyticWarningHWSimulator:
         # These simulators are being deprecated. Warning is raised in Qiskit 1.0
         # Migrate to AerSimulator with AerSimulator(method=method) and append
         # run circuits with the `save_state` instruction.
-        assert len(recwarn) == 1 if Version("1.0") < Version(qk.__version__) else 0
+        assert len(recwarn) == (1 if Version("1.0") < Version(qk.__version__) else 0)
 
 
 class TestAerBackendOptions:


### PR DESCRIPTION
`Conditional` checks were failing as they were trying to check equality between underlying measurements, which will turn out to be false due to different hash resulting from different `id`.