### PR TITLE
Add measurements keyword argument to use of `from_qasm`

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -306,7 +306,7 @@ class TestLoadIntegration:
 
         @qml.qnode(dev)
         def loaded_quantum_circuit():
-            qml.from_qasm(TestLoadIntegration.hadamard_qasm)(wires=[0])
+            qml.from_qasm(TestLoadIntegration.hadamard_qasm, measurements=[])(wires=[0])
             return qml.expval(qml.PauliZ(0))
 
         @qml.qnode(dev)
@@ -325,7 +325,7 @@ class TestLoadIntegration:
             f.write(TestLoadIntegration.hadamard_qasm)
 
         with open(apply_hadamard, "r", encoding="utf") as f:
-            hadamard = qml.from_qasm(f.read())
+            hadamard = qml.from_qasm(f.read(), measurements=[])
 
         dev = qml.device("default.qubit", wires=2)
 


### PR DESCRIPTION
Deprecation of default behaviour in `from_qasm` led to test failures https://github.com/PennyLaneAI/pennylane/pull/5882
Update use of `qml.from_qasm` in integration tests