### PR TITLE
Add error message for shot vectors for QiskitDevice

### DIFF
--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -178,6 +178,11 @@ class QiskitDevice(QubitDevice, abc.ABC):
 
             self.shots = 1024
 
+        if shots and not isinstance(shots, int):
+            raise ValueError(
+                f"Shots needs to be an integer value. Shot vectors are not supported for {self.name}."
+            )
+
         self._capabilities["returns_state"] = self._is_state_backend
 
         # Perform validation against backend

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -326,3 +326,15 @@ class TestBatchExecution:
         res = barrier_func()
         assert barrier_func.tape.operations[0] == qml.Barrier([0, 1])
         assert np.allclose(res, dev.batch_execute([barrier_func.tape]), atol=0)
+
+def test_aer_device_shots_value_error():
+    """Tests that aer device raises an error when given a shot vector"""
+    with pytest.raises(
+        ValueError, match="Shots needs to be an integer value. Shot vectors are not supported"
+    ):
+        AerDevice(backend="aer_simulator", wires=1, shots=(1, 1, 1))
+
+    with pytest.raises(
+        ValueError, match="Shots needs to be an integer value. Shot vectors are not supported"
+    ):
+        AerDevice(backend="aer_simulator", wires=1, shots=[1, 1, 1])

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -327,6 +327,7 @@ class TestBatchExecution:
         assert barrier_func.tape.operations[0] == qml.Barrier([0, 1])
         assert np.allclose(res, dev.batch_execute([barrier_func.tape]), atol=0)
 
+
 def test_aer_device_shots_value_error():
     """Tests that aer device raises an error when given a shot vector"""
     with pytest.raises(


### PR DESCRIPTION
As mentioned by @CatalinaAlbornoz in issue #575, there's a bug that's ultimately related to `qiskit.aer` not supporting shot vectors (@albi3ro). While the functionality is still not supported, in this PR, we add a more useful error message to capture this behaviour.

This error message already exists in the new device API so there's no additional work on that front.