### PR TITLE
Fix deprecated import path for `QubitDevice`

### DIFF
--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -27,7 +27,8 @@ from qiskit.compiler import transpile
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.providers import Backend, BackendV2, QiskitBackendNotFoundError
 
-from pennylane import QubitDevice, DeviceError
+from pennylane import DeviceError
+from pennylane.devices import QubitDevice
 from pennylane.measurements import SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP
 
 from .converter import QISKIT_OPERATION_MAP


### PR DESCRIPTION
pennylane.QubitDevice is deprecated in v0.39, importing QubitDevice from pennylane.devices instead.