### PR TITLE
Fix test improperly comparing measurement values

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1647,10 +1647,12 @@ class TestConverterIntegration:
         qc1.measure(1, 1)
 
         qtemp, qtemp1 = load(qc), load(qc1)
-        assert qtemp()[0] == qml.measure(0) and qtemp1()[0] == qml.measure(2)
+        assert qml.equal(qtemp()[0], qml.measure(0))
+        assert qml.equal(qtemp1()[0], qml.measure(2))
 
         qtemp2 = load(qc, measurements=[qml.expval(qml.PauliZ(0))])
-        assert qtemp()[0] != qtemp2()[0] and qtemp2()[0] == qml.expval(qml.PauliZ(0))
+        assert not qml.equal(qtemp()[0], qtemp2()[0])
+        qml.assert_equal(qtemp2()[0], qml.expval(qml.PauliZ(0)) )
 
 
 class TestConverterPennyLaneCircuitToQiskit:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1639,6 +1639,12 @@ class TestConverterIntegration:
         qc.cx(0, 1)
         qc.measure(1, 1)
 
+        m1, m2 = load(qc)()
+        for m, w in zip((m1, m2), (0, 1)):
+            assert isinstance(m, qml.measurements.MeasurementValue)
+            assert len(m.measurements) == 1
+            assert m.measurements[0].wires == qml.wires.Wires(w)
+
         qc1 = QuantumCircuit(3, 3)
         qc1.h(0)
         qc1.measure(2, 2)
@@ -1646,13 +1652,11 @@ class TestConverterIntegration:
         qc1.cx(0, 1)
         qc1.measure(1, 1)
 
-        qtemp, qtemp1 = load(qc), load(qc1)
-        assert qml.equal(qtemp()[0], qml.measure(0))
-        assert qml.equal(qtemp1()[0], qml.measure(2))
-
-        qtemp2 = load(qc, measurements=[qml.expval(qml.PauliZ(0))])
-        assert not qml.equal(qtemp()[0], qtemp2()[0])
-        qml.assert_equal(qtemp2()[0], qml.expval(qml.PauliZ(0)) )
+        m1, m2 = load(qc1)()
+        for m, w in zip((m1, m2), (2, 1)):
+            assert isinstance(m, qml.measurements.MeasurementValue)
+            assert len(m.measurements) == 1
+            assert m.measurements[0].wires == qml.wires.Wires(w)
 
 
 class TestConverterPennyLaneCircuitToQiskit:


### PR DESCRIPTION
A test was comparing equality of measurment values using `==`, even though that returns another measurement value instead of boolean.  Now that measruement values are intrinsically truthy and instead raise an error when used as a boolean, this test is raising an error.

This change fixes it to use `qml.equal` and `qml.assert_equal` instead of `bool(m1 == m2)`.