### PR TITLE
Let users import from pennylane_qiskit

### DIFF
--- a/pennylane_qiskit/__init__.py
+++ b/pennylane_qiskit/__init__.py
@@ -18,3 +18,4 @@ from .aer import AerDevice
 from .basic_sim import BasicSimulatorDevice
 from .remote import RemoteDevice
 from .converter import load, load_pauli_op, load_qasm, load_qasm_from_file, load_noise_model
+from .qiskit_device import qiskit_session

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -94,10 +94,10 @@ def qiskit_session(device, **kwargs):
     Args:
         device (QiskitDevice2): the device that will create remote tasks using the session
         **kwargs: session keyword arguments to be used for settings for the Session. At the
-        time of writing, the only relevant keyword argument is "max_time", which lets you
-        set the maximum amount of time the sessin is open. For the most up to date information,
-        please refer to the Qiskit Session
-        `documentation <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session>`_.
+            time of writing, the only relevant keyword argument is "max_time", which lets you
+            set the maximum amount of time the sessin is open. For the most up to date information,
+            please refer to the Qiskit Session
+            `documentation <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session>`_.
 
     **Example:**
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -95,7 +95,7 @@ def qiskit_session(device, **kwargs):
         device (QiskitDevice2): the device that will create remote tasks using the session
         **kwargs: session keyword arguments to be used for settings for the Session. At the
             time of writing, the only relevant keyword argument is "max_time", which lets you
-            set the maximum amount of time the sessin is open. For the most up to date information,
+            set the maximum amount of time the session is open. For the most up to date information,
             please refer to the Qiskit Session
             `documentation <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.Session>`_.
 


### PR DESCRIPTION
In the documentation for qiskit_session and [the demo for using IBM with pennylane-qiskit](https://pennylane.ai/qml/demos/ibm_pennylane/), we import qiskit_session using `from pennylane_qiskit import qiskit_session`. But this doesn't actually work because it is not in `__init__.py`. 

[sc-77085]