### PR TITLE
Delete references to the removed `QubitStateVector` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking changes 💔
 
+* The ``qml.QubitStateVector`` template has been removed. Instead, use :class:`~pennylane.StatePrep`.
+
 ### Deprecations 👋
 
 ### Documentation 📝
@@ -15,6 +17,8 @@
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Andrija Paurevic
 
 ---
 # Release 0.39.0

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -61,7 +61,6 @@ QISKIT_OPERATION_MAP = {
     "CRY": lib.CRYGate,
     "CRZ": lib.CRZGate,
     "PhaseShift": lib.PhaseGate,
-    "QubitStateVector": lib.Initialize,
     "StatePrep": lib.Initialize,
     "Toffoli": lib.CCXGate,
     "QubitUnitary": lib.UnitaryGate,
@@ -527,7 +526,7 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
             elif instruction_name in inv_map:
                 operation_class = getattr(pennylane_ops, inv_map[instruction_name])
                 operation_args.extend(operation_params)
-                if operation_class in (qml.QubitStateVector, qml.StatePrep):
+                if operation_class is qml.StatePrep:
                     operation_args = [np.array(operation_params)]
 
             elif isinstance(instruction, Measure):
@@ -747,7 +746,7 @@ def operation_to_qiskit(operation, reg, creg=None):
 
     # Need to revert the order of the quantum registers used in
     # Qiskit such that it matches the PennyLane ordering
-    if operation in ("QubitUnitary", "QubitStateVector", "StatePrep"):
+    if operation in ("QubitUnitary", "StatePrep"):
         qregs = list(reversed(qregs))
 
     if creg:

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -301,7 +301,7 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
 
             qregs = [self._reg[i] for i in device_wires.labels]
 
-            if operation in ("QubitUnitary", "QubitStateVector", "StatePrep"):
+            if operation in ("QubitUnitary", "StatePrep"):
                 # Need to revert the order of the quantum registers used in
                 # Qiskit such that it matches the PennyLane ordering
                 qregs = list(reversed(qregs))
@@ -327,9 +327,9 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
             operation (pennylane.Operation): operation to be checked
 
         Raises:
-            DeviceError: If the operation is QubitStateVector or StatePrep
+            DeviceError: If the operation is StatePrep
         """
-        if operation in ("QubitStateVector", "StatePrep"):
+        if operation == "StatePrep":
             if self._is_unitary_backend:
                 raise DeviceError(
                     f"The {operation} operation "


### PR DESCRIPTION
**Context:**

Completing the deprecation cycle of `QubitStateVector` (see https://github.com/PennyLaneAI/pennylane/pull/6525)

**Description of the Change:**

Removed all references to the deprecated source code.

[sc-77482]