### PR TITLE
Update deprecated usage of `tape` and `qtape` properties in `QNode`

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2098,10 +2098,13 @@ class TestControlOpIntegration:
             qml.Barrier([0, 1, 2])
             return [qml.expval(m) for m in [m0, m1, qml.measure(0), qml.measure(1), qml.measure(2)]]
 
+        loaded_qiskit_circuit_tape = qml.workflow.construct_tape(loaded_qiskit_circuit)()
+        built_pl_circuit_tape = qml.workflow.construct_tape(built_pl_circuit)()
+
         assert loaded_qiskit_circuit() == built_pl_circuit()
-        assert len(loaded_qiskit_circuit.tape.operations) == len(built_pl_circuit.tape.operations)
+        assert len(loaded_qiskit_circuit_tape.operations) == len(built_pl_circuit_tape.operations)
         for op1, op2 in zip(
-            loaded_qiskit_circuit.tape.operations, built_pl_circuit.tape.operations
+            loaded_qiskit_circuit_tape.operations, built_pl_circuit_tape.operations
         ):
             if isinstance(op1, MidMeasureMP) or isinstance(op2, MidMeasureMP):
                 assert op1.wires == op2.wires
@@ -2187,11 +2190,12 @@ class TestControlOpIntegration:
 
             return qml.expval(qml.PauliZ(0) @ qml.PauliY(1))
 
+        loaded_qiskit_circuit_tape = qml.workflow.construct_tape(loaded_qiskit_circuit)()
+        built_pl_circuit_tape = qml.workflow.construct_tape(built_pl_circuit)()
         assert loaded_qiskit_circuit() == built_pl_circuit()
-
-        assert len(loaded_qiskit_circuit.tape.operations) == len(built_pl_circuit.tape.operations)
+        assert len(loaded_qiskit_circuit_tape.operations) == len(built_pl_circuit_tape.operations)
         for op1, op2 in zip(
-            loaded_qiskit_circuit.tape.operations, built_pl_circuit.tape.operations
+            loaded_qiskit_circuit_tape.operations, built_pl_circuit_tape.operations
         ):
             if isinstance(op1, MidMeasureMP) or isinstance(op2, MidMeasureMP):
                 assert op1.wires == op2.wires
@@ -2285,9 +2289,11 @@ class TestControlOpIntegration:
             qml.cond(m1 == 1, qml.PauliX)(wires=[2])
             return qml.expval(qml.PauliZ(0))
 
+        qk_circuit_tape = qml.workflow.construct_tape(qk_circuit)()
+        pl_circuit_tape = qml.workflow.construct_tape(pl_circuit)()
         assert qk_circuit() == pl_circuit()
-        assert len(qk_circuit.tape.operations) == len(pl_circuit.tape.operations)
-        for op1, op2 in zip(qk_circuit.tape.operations, pl_circuit.tape.operations):
+        assert len(qk_circuit_tape.operations) == len(pl_circuit_tape.operations)
+        for op1, op2 in zip(qk_circuit_tape.operations, pl_circuit_tape.operations):
             if isinstance(op1, MidMeasureMP) or isinstance(op2, MidMeasureMP):
                 assert op1.wires == op2.wires
             elif isinstance(op1, qml.ops.Conditional) or isinstance(op2, qml.ops.Conditional):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -446,8 +446,8 @@ class TestPLTemplates:
             return qml.expval(qml.PauliZ(0))
 
         phi = tensor([[0.04439891, 0.14490549, 3.29725643, 2.51240058]])
-        circuit(phi)
-        ops = circuit.tape.operations
+        tape = qml.workflow.construct_tape(circuit)(phi)
+        ops = tape.operations
         for i in range(phi.shape[1]):
             # Test each rotation applied
             assert ops[i].name == "RX"
@@ -469,8 +469,8 @@ class TestPLTemplates:
 
         phi = tensor([[0.04439891, 0.14490549, 3.29725643]])
 
-        circuit(phi)
-        ops = circuit.tape.operations
+        tape = qml.workflow.construct_tape(circuit)(phi)
+        ops = tape.operations
         # Test the rotation applied
         assert ops[0].name == "Rot"
         assert len(ops[0].parameters) == 3

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -320,5 +320,6 @@ class TestBatchExecution:
             return qml.state()
 
         res = barrier_func()
-        assert barrier_func.tape.operations[0] == qml.Barrier([0, 1])
-        assert np.allclose(res, dev.batch_execute([barrier_func.tape]), atol=0)
+        tape = qml.workflow.construct_tape(barrier_func)()
+        assert tape.operations[0] == qml.Barrier([0, 1])
+        assert np.allclose(res, dev.batch_execute([tape]), atol=0)


### PR DESCRIPTION
Summary:

Updating deprecated code that was introduced from a recent deprecation https://github.com/PennyLaneAI/pennylane/pull/6583.

[sc-76836]