### PR TITLE
Pinning qiskit version in the requirements

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,5 @@
 pennylane>=0.38
-qiskit
+qiskit<=1.2.0
 qiskit-ibm-runtime<=0.29
 numpy
 sympy==1.12

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,5 @@
 pennylane>=0.38
-qiskit<=1.2.4
+qiskit<1.3
 qiskit-ibm-runtime<=0.29
 numpy
 sympy==1.12

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,5 @@
 pennylane>=0.38
-qiskit<=1.2.0
+qiskit<=1.2.4
 qiskit-ibm-runtime<=0.29
 numpy
 sympy==1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pennylane>=0.32
-qiskit<=1.2.4
+qiskit<1.3
 qiskit-ibm-runtime<=0.29
 numpy
 sympy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pennylane>=0.32
-qiskit<=1.2.0
+qiskit<=1.2.4
 qiskit-ibm-runtime<=0.29
 numpy
 sympy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pennylane>=0.32
-qiskit
+qiskit<=1.2.0
 qiskit-ibm-runtime<=0.29
 numpy
 sympy


### PR DESCRIPTION
IBM [has released `qiskit 1.3.0`](https://pypi.org/project/qiskit/) on November 28th and this broke the `pennylane-qiskit` plugin (see [here](https://github.com/PennyLaneAI/plugin-test-matrix/actions/runs/12110413926/job/33760762560) for details about the failure).

We pin `qiskit` to version `<1.3` so that it works again until we update the plugin