### PR TITLE
Pinning `qiskit` in `setup.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,18 @@
 
 ### Bug fixes 🐛
 
+### Other changes 
+
+* The `qiskit` dependency has been temporarily pinned to version `<1.3` to prevent wrong results. 
+  At present, `pennylane-qiskit` is incompatible with `qiskit 1.3`.
+  [(#603)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/603) 
+  [(#604)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/604)   
+
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
 
+Pietropaolo Frisoni,
 Andrija Paurevic
 
 ---

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 requirements = [
-    "qiskit>=0.32",
+    "qiskit>=0.32,<1.3",
     "qiskit-aer",
     "qiskit-ibm-runtime<=0.29",
     "qiskit-ibm-provider",
@@ -33,39 +33,39 @@ requirements = [
 ]
 
 info = {
-    'name': 'PennyLane-qiskit',
-    'version': version,
-    'maintainer': 'Xanadu',
-    'maintainer_email': 'software@xanadu.ai',
-    'url': 'https://github.com/XanaduAI/pennylane-qiskit',
-    'license': 'Apache License 2.0',
-    'packages': [
-        'pennylane_qiskit'
-    ],
-    'entry_points': {
-        'pennylane.plugins': [
-            'qiskit.remote = pennylane_qiskit:RemoteDevice',
-            'qiskit.aer = pennylane_qiskit:AerDevice',
-            'qiskit.basicaer = pennylane_qiskit:BasicAerDevice',
-            'qiskit.basicsim = pennylane_qiskit:BasicSimulatorDevice',
-            ],
-        'pennylane.io': [
-            'qiskit = pennylane_qiskit:load',
-            'qiskit_op = pennylane_qiskit:load_pauli_op',
-            'qiskit_noise = pennylane_qiskit:load_noise_model',
-            'qasm = pennylane_qiskit:load_qasm',
-            'qasm_file = pennylane_qiskit:load_qasm_from_file',
-            ],
-        },
-    'description': 'PennyLane plugin for Qiskit',
-    'long_description': open('README.rst').read(),
-    'provides': ["pennylane_qiskit"],
-    'install_requires': requirements,
+    "name": "PennyLane-qiskit",
+    "version": version,
+    "maintainer": "Xanadu",
+    "maintainer_email": "software@xanadu.ai",
+    "url": "https://github.com/XanaduAI/pennylane-qiskit",
+    "license": "Apache License 2.0",
+    "packages": ["pennylane_qiskit"],
+    "entry_points": {
+        "pennylane.plugins": [
+            "qiskit.remote = pennylane_qiskit:RemoteDevice",
+            "qiskit.aer = pennylane_qiskit:AerDevice",
+            "qiskit.basicaer = pennylane_qiskit:BasicAerDevice",
+            "qiskit.basicsim = pennylane_qiskit:BasicSimulatorDevice",
+        ],
+        "pennylane.io": [
+            "qiskit = pennylane_qiskit:load",
+            "qiskit_op = pennylane_qiskit:load_pauli_op",
+            "qiskit_noise = pennylane_qiskit:load_noise_model",
+            "qasm = pennylane_qiskit:load_qasm",
+            "qasm_file = pennylane_qiskit:load_qasm_from_file",
+        ],
+    },
+    "description": "PennyLane plugin for Qiskit",
+    "long_description": open("README.rst").read(),
+    "provides": ["pennylane_qiskit"],
+    "install_requires": requirements,
     # 'extras_require': extra_requirements,
-    'command_options': {
-        'build_sphinx': {
-            'version': ('setup.py', version),
-            'release': ('setup.py', version)}}
+    "command_options": {
+        "build_sphinx": {
+            "version": ("setup.py", version),
+            "release": ("setup.py", version),
+        }
+    },
 }
 
 classifiers = [
@@ -79,12 +79,12 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
-    'Programming Language :: Python :: 3.12',
-    'Programming Language :: Python :: 3 :: Only',
-    "Topic :: Scientific/Engineering :: Physics"
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Scientific/Engineering :: Physics",
 ]
 
 setup(classifiers=classifiers, **(info))


### PR DESCRIPTION
This PR implements a **hard** pin on `qiskit` so that the latter automatically downgrades to `qiskit 1.2.4` (that works with this plugin) if the latest version of `qiskit` (that is, `qiskit 1.3.0`, which does not currently work with this plugin) is installed.

With this hard pin, if a user has the latest version of `qiskit` and installs the `pennylane-qiskit` plugin, the `qiskit` version is automatically downgraded to the previous one (which does not provide wrong results).

Vice versa, if the user installs the latest `pennylane-qiskit` and then the latest `qiskit` version, he/she should receive the message:
```
pennylane-qiskit 0.40.XXX requires qiskit<1.3.0,>=0.32, but you have qiskit 1.3.0 which is incompatible
```