### PR TITLE
Fix premature session closure error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,16 @@
 
 ### Documentation 📝
 
-### Bug fixes 🐛
+### Bug fixes 🐛  
+* Fixed premature session closure after a single execution when using `qiskit_device.qiskit_session`.  
+  [(#608)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/608)
 
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
 
 Andrija Paurevic
+Tak Hur(@takh04)
 
 ---
 # Release 0.39.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Documentation 📝
 
 ### Bug fixes 🐛  
-* Fixed premature session closure after a single execution when using `qiskit_device.qiskit_session`.  
+* Fixed premature session closure when using `qiskit_session`.  
   [(#608)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/608)
 
 ### Contributors ✍️
@@ -22,7 +22,7 @@
 This release contains contributions from (in alphabetical order):
 
 Andrija Paurevic
-Tak Hur(@takh04)
+Tak Hur
 
 ---
 # Release 0.39.1

--- a/pennylane_qiskit/converter.py
+++ b/pennylane_qiskit/converter.py
@@ -573,7 +573,6 @@ def load(quantum_circuit: QuantumCircuit, measurements=None):
                         mid_circ_regs[carg] = mid_circ_meas[-1]
 
             else:
-
                 try:
                     if not isinstance(instruction, (ControlFlowOp,)):
                         operation_args = [instruction.to_matrix()]

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -15,7 +15,8 @@ r"""
 This module contains a prototype base class for constructing Qiskit devices
 for PennyLane with the new device API.
 """
-# pylint: disable=too-many-instance-attributes,attribute-defined-outside-init
+# pylint: disable=too-many-instance-attributes,attribute-defined-outside-init,too-many-positional-arguments
+
 
 
 import warnings

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -592,7 +592,8 @@ class QiskitDevice(Device):
                     results.append(execute_fn(circ, session))
                 yield results
             finally:
-                session.close()
+                if self._session is None:
+                    session.close()
 
         with execute_circuits(session) as results:
             return results

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -18,7 +18,6 @@ for PennyLane with the new device API.
 # pylint: disable=too-many-instance-attributes,attribute-defined-outside-init,too-many-positional-arguments
 
 
-
 import warnings
 import inspect
 from typing import Union, Callable, Tuple, Sequence
@@ -326,7 +325,6 @@ class QiskitDevice(Device):
         compile_backend=None,
         **kwargs,
     ):
-
         if shots is None:
             warnings.warn(
                 "Expected an integer number of shots, but received shots=None. Defaulting "

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -105,7 +105,6 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
     _eigs = {}
 
     def __init__(self, wires, provider, backend, shots=1024, **kwargs):
-
         super().__init__(wires=wires, shots=shots)
 
         self.provider = provider


### PR DESCRIPTION
[This issue ](https://github.com/PennyLaneAI/pennylane-qiskit/issues/607) shows pennylane-qiskit session closes prematurely. Simply adding _if self._session is None:_ fixes the problem. The fix is tested on both IBM fake device and real devices.