### PR TITLE
SC83912 | Enable PL.ai Search

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -293,7 +293,8 @@ html_theme_options = {
         "of Google Inc."
     ],
     "toc_overview": True,
-    "google_analytics_tracking_id": "G-C480Z9JL0D"
+    "google_analytics_tracking_id": "G-C480Z9JL0D",
+    "search_on_pennylane_ai": True,
 }
 
 edit_on_github_project = 'PennyLaneAI/pennylane-qiskit'


### PR DESCRIPTION
## Changes
- `search_on_pennylane_ai` is `True`

## Testing
In the [docs preview](https://xanaduai-pennylane--617.com.readthedocs.build/projects/qiskit/en/617/), when using the search, confirm that you are redirected to pennylane.ai/search and `project=pennylane-qiskit` is included in the URL

## Note
Lightning docs will not appear in production at the moment 