### PR TITLE
Adjustments to changelog after the 0.40.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,6 @@
 
 ### Documentation 📝
 
-### Internal changes
-
-* Pinning `setuptools` in the CI to update how the plugin is installed.
-  [(#620)](https://github.com/PennyLaneAI/pennylane-cirq/pull/620)
-
-* Pinning `qiskit.aer` in the `setup.py` file to maintain compatibility with the plugin.
-  [(#620)](https://github.com/PennyLaneAI/pennylane-cirq/pull/620)
-
 ### Bug fixes 🐛
 
 * The layout of the circuit is now applied to the observables when it is changed on transpilation.
@@ -27,8 +19,24 @@
 
 This release contains contributions from (in alphabetical order):
 
-Pietropaolo Frisoni
 Juan Felipe Huan Lew Yee
+
+---
+# Release 0.40.1
+
+### Internal changes ⚙️
+
+* Pinning `setuptools` in the CI to update how the plugin is installed.
+  [(#620)](https://github.com/PennyLaneAI/pennylane-cirq/pull/620)
+
+* Pinning `qiskit.aer` in the `setup.py` file to maintain compatibility with the plugin.
+  [(#620)](https://github.com/PennyLaneAI/pennylane-cirq/pull/620)
+
+### Contributors ✍️
+
+This release contains contributions from (in alphabetical order):
+
+Pietropaolo Frisoni
 
 ---
 # Release 0.40.0


### PR DESCRIPTION
**Description of the change**: After releasing the `0.40.1` version with the required changes to maintain compatibility between stable `Pennylane` and stable `Pennylane-qiskit`, we need to update the `changelog` in the `master` branch to reflect the fact that an intermediate release happened in between `0.40.0` and `0.41.0`.

- The internal changes required for the `0.40.1` release have been moved to the corresponding changelog section

- Every other entry of the `0.41-dev` changelog (currently just one) has been kept for the upcoming release, which is about one month from now