### PR TITLE
Update Sphinx-action version to tag

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: PennyLaneAI/sphinx-action@master
+    - uses: PennyLaneAI/sphinx-action@3.9
       with:
         docs-folder: "doc/"
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: PennyLaneAI/sphinx-action@3.9
+    - uses: PennyLaneAI/sphinx-action@master
       with:
         docs-folder: "doc/"
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,6 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
   apt_packages:
     - graphviz

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath('.')), 'doc'))
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.6'
+needs_sphinx = '8.1'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom


### PR DESCRIPTION
docs.yml currently uses sphinx-action to run the documentation checks. Sphinx-action is being upgraded to python 3.10 which is incompatible with the existing docs.yml workflow. This PR will update docs.yml to use a version of sphinx-action that is pegged to python 3.9 and a lower version of sphinx. 

This repo is already using sphinx-7.4.7 with python3.9.