### PR TITLE
Update ubuntu version to 24.04 in readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ python:
       path: .
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
   apt_packages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  * Updated tests to keep into account that wires validation on `default.qubit` in PennyLane now takes place 
   after the `mid_circuit_measurements` transform is applied during preprocessing.
   [(#628)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/628)
+  * Bumped `readthedocs.yml` up to Ubuntu-24.04 [(#629)](https://github.com/PennyLaneAI/pennylane-rigetti/pull/175)
  
  ### Documentation 📝
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
  * Updated tests to keep into account that wires validation on `default.qubit` in PennyLane now takes place 
   after the `mid_circuit_measurements` transform is applied during preprocessing.
   [(#628)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/628)
-  * Bumped `readthedocs.yml` up to Ubuntu-24.04 [(#629)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/629)
+
+  * Bumped the `readthedocs.yml` action up to Ubuntu-24.04.
+    [(#629)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/629)
  
  ### Documentation 📝
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
  * Updated tests to keep into account that wires validation on `default.qubit` in PennyLane now takes place 
   after the `mid_circuit_measurements` transform is applied during preprocessing.
   [(#628)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/628)
-  * Bumped `readthedocs.yml` up to Ubuntu-24.04 [(#629)](https://github.com/PennyLaneAI/pennylane-rigetti/pull/175)
+  * Bumped `readthedocs.yml` up to Ubuntu-24.04 [(#629)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/629)
  
  ### Documentation 📝
 


### PR DESCRIPTION
**Description of the Change:**
Upgrading the readthedocs.yml runner to Ubuntu-24.04 from Ubuntu22.04; 22.04 is in end of life.

**Benefits:**
The readthedocs runner gets upgrade.

**Possible Drawbacks:**
There could be potential compatibility issues with sphinx and other packages. None were found in the PR run.

**Related GitHub Issues:**
