### PR TITLE
fix `test_build_kraus_error_ops` by unpacking hyperparameters

### DIFF
--- a/tests/test_noise_models.py
+++ b/tests/test_noise_models.py
@@ -146,7 +146,9 @@ class TestLoadNoiseChannels:
         choi_mat1 = self._kraus_to_choi(
             pl_op_from_qiskit.compute_kraus_matrices(*pl_op_from_qiskit.data)
         )
-        choi_mat2 = self._kraus_to_choi(pl_channel.compute_kraus_matrices(*pl_channel.data))
+        choi_mat2 = self._kraus_to_choi(
+            pl_channel.compute_kraus_matrices(*pl_channel.data, **pl_channel.hyperparameters)
+        )
         assert np.allclose(choi_mat1, choi_mat2)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
**Context:**

https://github.com/PennyLaneAI/pennylane/pull/7618 broke our CI by removing `operators` from `op.data` and instead having it be in `op.hyperparameters`.

**Description of the change:**

Unpack hyperparameters into the function. 👍🏼 

[sc-92969]