### PR TITLE
replace `DefaultExecutionConfig` with `ExecutionConfig()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
  ### Internal changes ⚙️
 
+ * Replace `DefaultExecutionConfig` with `ExecutionConfig()` and use `dataclasses.replace` to update
+   configurations to not mutate properties.
+  [(#634)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/634)
+
  * Updated tests to keep into account that wires validation on `default.qubit` in PennyLane now takes place 
   after the `mid_circuit_measurements` transform is applied during preprocessing.
   [(#628)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/628)

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -66,6 +66,8 @@ def custom_simulator_tracking(cls):
 
     @wraps(tracked_execute)
     def execute(self, circuits, execution_config: ExecutionConfig = None):
+        if execution_config is None:
+            execution_config = ExecutionConfig()
         results = tracked_execute(self, circuits, execution_config)
         if self.tracker.active:
             res = []
@@ -448,7 +450,7 @@ class QiskitDevice(Device):
         * Does not intrinsically support parameter broadcasting
 
         """
-        config = execution_config
+        config = execution_config or ExecutionConfig()
 
         config = replace(config, use_device_gradient=False)
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -431,7 +431,7 @@ class QiskitDevice(Device):
 
     def preprocess(
         self,
-        execution_config: ExecutionConfig = None,
+        execution_config: Optional[ExecutionConfig] = None,
     ) -> Tuple[TransformProgram, ExecutionConfig]:
         """This function defines the device transform program to be applied and an updated device configuration.
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -23,7 +23,7 @@ import inspect
 from dataclasses import replace
 
 
-from typing import Union, Tuple, Sequence, Callable
+from typing import Union, Tuple, Sequence, Callable, Optional
 from contextlib import contextmanager
 from functools import wraps
 

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -65,7 +65,7 @@ def custom_simulator_tracking(cls):
     tracked_execute = cls.execute
 
     @wraps(tracked_execute)
-    def execute(self, circuits, execution_config: ExecutionConfig = None):
+    def execute(self, circuits, execution_config: Optional[ExecutionConfig] = None):
         if execution_config is None:
             execution_config = ExecutionConfig()
         results = tracked_execute(self, circuits, execution_config)

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -569,7 +569,7 @@ class QiskitDevice(Device):
     def execute(
         self,
         circuits: QuantumTape_or_Batch,
-        execution_config: ExecutionConfig = None,
+        execution_config: Optional[ExecutionConfig] = None,
     ) -> Result_or_ResultBatch:
         """Execute a circuit or a batch of circuits and turn it into results."""
         session = self._session


### PR DESCRIPTION
**Context:**

https://github.com/PennyLaneAI/pennylane/pull/7697 changed the default usage of `ExecutionConfig` to not be `DefaultExecutionConfig` but instead just creating a new instance of `ExecutionConfig`.

**Description of the Change:**

As outlined above.

**Benefits:** Better code.

**Possible Drawbacks:** None identified.

[sc-93612]