### PR TITLE
Fix number of wires in `QubitChannel` in converted noise models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,15 @@
 
 * Stops queuing a mid circuit measurement on first use of `qml.from_qiskit`.
  [(#630)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/630)
- 
+
+* `qml.QubitChannel` in a converted noise model should now act on correct number of qubits.
+  [(#640)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/640)
+
  ### Contributors ✍️
  
  This release contains contributions from (in alphabetical order):
 
+ Utkarsh Azad,
  Pietropaolo Frisoni,
  Andrew Gardhouse,
  Austin Huang,

--- a/pennylane_qiskit/noise_models.py
+++ b/pennylane_qiskit/noise_models.py
@@ -79,7 +79,9 @@ def _build_qerror_op(error) -> qml.QubitChannel:
     except Exception as exc:  # pragma: no cover
         raise ValueError(f"Error {error} could not be converted.") from exc
 
-    return qml.QubitChannel(K_list=kraus_matrices, wires="DummyTempWire")
+    num_wires = int(qml.math.log2(kraus_matrices[0].shape[0]))
+    kraus_wires = [f"DummyTempWire{i}" for i in range(num_wires)]
+    return qml.QubitChannel(K_list=kraus_matrices, wires=kraus_wires)
 
 
 def _build_noise_model_map(noise_model) -> Tuple[dict, dict]:

--- a/tests/test_noise_models.py
+++ b/tests/test_noise_models.py
@@ -138,6 +138,21 @@ class TestLoadNoiseChannels:
                     wires="ANY",
                 ),
             ),
+            (
+                noise.kraus_error(
+                    [
+                        np.diag([-0.9486833] * 4),
+                        np.diag([-0.31622777] * 2, k=2) + np.diag([-0.31622777] * 2, k=-2),
+                    ],
+                ),
+                qml.QubitChannel(
+                    [
+                        np.diag([-0.9486833] * 4),
+                        np.diag([-0.31622777] * 2, k=2) + np.diag([-0.31622777] * 2, k=-2),
+                    ],
+                    wires=["ANY1", "ANY2"],
+                ),
+            ),
         ],
     )
     def test_build_kraus_error_ops(self, qiskit_error, pl_channel):


### PR DESCRIPTION
Use information from the Kraus matrices to fix the number of wires in `QubitChannel` in converted noise models.

More context - 

For a noise model, where noise function is constrcuted with a `qml.noise.conditional.partial_wires` - we zip over the list of temporary wires (now called as "DummyTempWire") and operator wires to obtain the set of wires on which the noise has to be applied. This can be seen ([here](https://github.com/PennyLaneAI/pennylane/blob/08b3c20567d29698b3f4fa86e85efa80f0ea8e9c/pennylane/noise/conditionals.py#L760)). Currently, by default, the number of temporary wires were being set as `one`, but in practice, they should match the wires on which the included Kraus matrices will be applied. So in this PR, we are taking that into account.
