### PR TITLE
Revert "incrementing the version number to v0.42.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.42.0
+# Release 0.42.0-dev
  
  ### New features since last release
  
@@ -8,9 +8,6 @@
   [(#630)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/630)
 
  ### Breaking changes 💔
-
-* Upgrade minimum supported version of PennyLane to 0.42.0.
-  [(#639)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/639)
  
  ### Deprecations 👋
 

--- a/pennylane_qiskit/_version.py
+++ b/pennylane_qiskit/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0"
+__version__ = "0.42.0-dev"

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -64,7 +64,7 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
     """
 
     name = "Qiskit PennyLane plugin"
-    pennylane_requires = ">=0.42.0"
+    pennylane_requires = ">=0.38.0"
     version = __version__
     plugin_version = __version__
     author = "Xanadu"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
     "qiskit-aer<0.16.1",
     "qiskit-ibm-runtime<=0.29",
     "qiskit-ibm-provider",
-    "pennylane>=0.42",
+    "pennylane>=0.38",
     "numpy",
     "sympy<1.13",
     "networkx>=2.2",


### PR DESCRIPTION
Reverts PennyLaneAI/pennylane-qiskit#639

This caused CI failures in pennylane repository which blocks merges to `rc` or `master`