### PR TITLE
Remove ibm_provider from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ requirements = [
     "qiskit>=0.32,<1.3",
     "qiskit-aer<0.16.1",
     "qiskit-ibm-runtime<=0.29",
-    "qiskit-ibm-provider",
     "pennylane>=0.38",
     "numpy",
     "sympy<1.13",


### PR DESCRIPTION
IBM provider is deprecated and it is raising errors in our quantum volume demo even though the plugin doesn't actually use it. We just need to remove it from setup.py and update conftest to use runtime instead. 