### PR TITLE
Fix minor typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ Contributing
 
 We welcome contributions - simply fork the repository of this plugin, and then make a
 `pull request <https://help.github.com/articles/about-pull-requests/>`_ containing your contribution.
-All contributers to this plugin will be listed as authors on the releases.
+All contributors to this plugin will be listed as authors on the releases.
 
 We also encourage bug reports, suggestions for new features and enhancements, and even links to cool projects
 or applications built on PennyLane.

--- a/doc/devices/aer.rst
+++ b/doc/devices/aer.rst
@@ -58,7 +58,7 @@ You can change a ``'qiskit.aer'`` device's backend with the ``backend`` argument
 
 .. note::
 
-    Occassionally, you may see others pass in a string as a backend. For example:
+    Occasionally, you may see others pass in a string as a backend. For example:
 
     .. code-block:: python
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -49,7 +49,7 @@ Backends
 ~~~~~~~~
 
 Qiskit devices have different **backends**, which define the actual simulator or hardware 
-used by the device. A backend instance should be initalized and passed to the device.
+used by the device. A backend instance should be initialized and passed to the device.
 
 Different simulator backends are optimized for different purposes. To change what backend is used, 
 a simulator backend can be defined as follows:

--- a/pennylane_qiskit/aer.py
+++ b/pennylane_qiskit/aer.py
@@ -34,7 +34,7 @@ class AerDevice(QiskitDeviceLegacy):
     `qiskit_aer documentation <https://qiskit.org/ecosystem/aer/index.html>`_.
 
     Args:
-        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+        wires (int or Iterable[Number, str]): Number of subsystems represented by the device,
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['ancilla', 'q1', 'q2']``).
         backend (str): the desired backend

--- a/pennylane_qiskit/basic_sim.py
+++ b/pennylane_qiskit/basic_sim.py
@@ -28,7 +28,7 @@ class BasicSimulatorDevice(QiskitDeviceLegacy):
     These options can be passed to this plugin device as keyword arguments.
 
     Args:
-        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+        wires (int or Iterable[Number, str]): Number of subsystems represented by the device,
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['aux_wire', 'q1', 'q2']``).
         backend (str): the desired backend

--- a/pennylane_qiskit/noise_models.py
+++ b/pennylane_qiskit/noise_models.py
@@ -65,7 +65,7 @@ with qml.QueuingManager.stop_recording():
 
 
 def _build_qerror_op(error) -> qml.QubitChannel:
-    """Builds a PennyLane error channel from a Qiksit ``QuantumError`` object.
+    """Builds a PennyLane error channel from a Qiskit ``QuantumError`` object.
 
     Args:
         error (QuantumError): Quantum error object

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -285,7 +285,7 @@ class QiskitDevice(Device):
     r"""Hardware/simulator Qiskit device for PennyLane.
 
     Args:
-        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+        wires (int or Iterable[Number, str]): Number of subsystems represented by the device,
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['aux_wire', 'q1', 'q2']``).
         backend (Backend): the initialized Qiskit backend
@@ -296,7 +296,7 @@ class QiskitDevice(Device):
         session (Session): a Qiskit Session to use for device execution. If none is provided, a session will
             be created at each device execution.
         compile_backend (Union[Backend, None]): the backend to be used for compiling the circuit that will be
-            sent to the backend device, to be set if the backend desired for compliation differs from the
+            sent to the backend device, to be set if the backend desired for compilation differs from the
             backend used for execution. Defaults to ``None``, which means the primary backend will be used.
         **kwargs: transpilation and runtime keyword arguments to be used for measurements with Primitives.
             If an `options` dictionary is defined amongst the kwargs, and there are settings that overlap

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -48,7 +48,7 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
     r"""Abstract Qiskit device for PennyLane.
 
     Args:
-        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+        wires (int or Iterable[Number, str]): Number of subsystems represented by the device,
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['ancilla', 'q1', 'q2']``).
         provider (Provider | None): The Qiskit backend provider.

--- a/pennylane_qiskit/remote.py
+++ b/pennylane_qiskit/remote.py
@@ -23,7 +23,7 @@ class RemoteDevice(QiskitDevice):
     """A PennyLane device for any Qiskit backend.
 
     Args:
-        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+        wires (int or Iterable[Number, str]): Number of subsystems represented by the device,
             or iterable that contains unique labels for the subsystems as numbers
             (i.e., ``[-1, 0, 2]``) or strings (``['aux_wire', 'q1', 'q2']``).
         backend (Backend): the initialized Qiskit backend
@@ -35,7 +35,7 @@ class RemoteDevice(QiskitDevice):
             a session will be created at each device execution.
         compile_backend (Union[Backend, None]): the backend to be used for compiling the circuit
             that will be sent to the backend device, to be set if the backend desired for
-            compliation differs from the backend used for execution. Defaults to ``None``,
+            compilation differs from the backend used for execution. Defaults to ``None``,
             which means the primary backend will be used.
         **kwargs: transpilation and runtime keyword arguments to be used for measurements with
             Primitives. If an `options` dictionary is defined amongst the kwargs, and there are

--- a/tests/test_noise_models.py
+++ b/tests/test_noise_models.py
@@ -22,7 +22,7 @@ import numpy as np
 import pennylane as qml
 
 # pylint:disable = wrong-import-position, unnecessary-lambda
-qiksit = pytest.importorskip("qiskit", "1.0.0")
+qiskit = pytest.importorskip("qiskit", "1.0.0")
 from qiskit_aer import noise
 from qiskit.quantum_info.operators.channel import Kraus
 


### PR DESCRIPTION
Fix minor typos
- contributers -> contributors
- Occassionally -> Occasionally
- initalized -> initialized
- `int or Iterable[Number, str]]` -> `int or Iterable[Number, str]`
- Qiksit -> Qiskit