### PR TITLE
Overload `batch_transform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   ```
 
   [(#650)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/650)
+  [(#654)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/654)
 
 ### Deprecations 👋
 

--- a/pennylane_qiskit/aer.py
+++ b/pennylane_qiskit/aer.py
@@ -56,7 +56,7 @@ class AerDevice(QiskitDeviceLegacy):
 
     short_name = "qiskit.aer"
 
-    def __init__(self, wires, shots=1024, backend="aer_simulator", method="automatic", **kwargs):
+    def __init__(self, wires, shots=None, backend="aer_simulator", method="automatic", **kwargs):
         if method != "automatic":
             backend += "_" + method
 

--- a/pennylane_qiskit/basic_sim.py
+++ b/pennylane_qiskit/basic_sim.py
@@ -45,5 +45,5 @@ class BasicSimulatorDevice(QiskitDeviceLegacy):
         "device are estimates based on samples."
     )
 
-    def __init__(self, wires, shots=1024, backend="basic_simulator", **kwargs):
+    def __init__(self, wires, shots=None, backend="basic_simulator", **kwargs):
         super().__init__(wires, provider=BasicProvider(), backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -341,7 +341,7 @@ class QiskitDevice(Device):
         self,
         wires,
         backend,
-        shots=1024,
+        shots=None,
         session=None,
         compile_backend=None,
         **kwargs,
@@ -524,7 +524,7 @@ class QiskitDevice(Device):
                 "Please use the `shots` keyword argument instead. The number of shots "
                 f"{shots} will be used instead."
             )
-        kwargs["default_shots"] = shots
+        kwargs["default_shots"] = shots or 1024
 
         kwargs, transpile_args = self.get_transpile_args(kwargs)
 

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -452,8 +452,10 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
             # At least one circuit must always be provided to the backend.
             return []
 
+        # Shots preprocessing
+        shots = circuits[0].shots.total_shots or self.shots
         # Send the batch of circuit objects using backend.run
-        self._current_job = self.backend.run(compiled_circuits, shots=self.shots, **self.run_args)
+        self._current_job = self.backend.run(compiled_circuits, shots=shots, **self.run_args)
 
         try:
             result = self._current_job.result(timeout=timeout)
@@ -470,14 +472,14 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
         for circuit, circuit_obj in zip(circuits, compiled_circuits):
             # Update the tracker
             if self.tracker.active:
-                self.tracker.update(executions=1, shots=self.shots)
+                self.tracker.update(executions=1, shots=shots)
                 self.tracker.record()
 
             if self._is_state_backend:
                 self._state = self._get_state(result, experiment=circuit_obj)
 
             # generate computational basis samples
-            if self.shots is not None or any(
+            if shots is not None or any(
                 isinstance(m, SAMPLE_TYPES) for m in circuit.measurements
             ):
                 self._samples = self.generate_samples(circuit_obj)

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -30,7 +30,6 @@ from qiskit.providers import Backend, BackendV2, QiskitBackendNotFoundError
 from pennylane.exceptions import DeviceError
 from pennylane.devices import QubitDevice
 from pennylane.measurements import SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP
-from pennylane.workflow import set_shots
 
 from .converter import QISKIT_OPERATION_MAP
 from ._version import __version__

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -142,13 +142,6 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
 
         self.process_kwargs(kwargs)
 
-    def expand_fn(self, circuit, max_expansion=10):
-        """Expand the circuit"""
-        if not (circuit.shots or self.shots or self._is_state_backend):
-            warnings.warn(self.analytic_warning_message.format(self.backend_name), UserWarning)
-            circuit = circuit.copy(shots=1024)
-        return super().expand_fn(circuit, max_expansion)
-
     def batch_transform(self, circuit):
         """Batch transform the circuit"""
         if not (circuit.shots or self.shots or self._is_state_backend):

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -29,7 +29,7 @@ from qiskit.providers import Backend, BackendV2, QiskitBackendNotFoundError
 
 from pennylane.exceptions import DeviceError
 from pennylane.devices import QubitDevice
-from pennylane.measurements import SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP
+from pennylane.measurements import SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP, Shots
 
 from .converter import QISKIT_OPERATION_MAP
 from ._version import __version__
@@ -152,8 +152,9 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
     def expand_fn(self, circuit, max_expansion=10):
         """Expand the circuit"""
         if not (circuit.shots or self.shots or self._is_state_backend):
-            warnings.warn(self.analytic_warning_message.format(backend), UserWarning)
+            warnings.warn(self.analytic_warning_message.format(self.backend_name), UserWarning)
             self.shots = 1024
+            circuit._shots = Shots(1024)
         return super().expand_fn(circuit, max_expansion)
 
     def process_kwargs(self, kwargs):
@@ -488,9 +489,7 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
                 self._state = self._get_state(result, experiment=circuit_obj)
 
             # generate computational basis samples
-            if shots is not None or any(
-                isinstance(m, SAMPLE_TYPES) for m in circuit.measurements
-            ):
+            if shots is not None or any(isinstance(m, SAMPLE_TYPES) for m in circuit.measurements):
                 self._samples = self.generate_samples(circuit_obj)
 
             res = self.statistics(circuit)

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -126,12 +126,6 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
 
             self.backend_name = _get_backend_name(self._backend)
 
-        # # Keep track if the user specified analytic to be True
-        # if shots is None and not self._is_state_backend:
-        #     # Raise a warning if no shots were specified for a hardware device
-        #     warnings.warn(self.analytic_warning_message.format(backend), UserWarning)
-
-        #     self.shots = 1024
 
         self._capabilities["returns_state"] = self._is_state_backend
 
@@ -153,8 +147,7 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
         """Expand the circuit"""
         if not (circuit.shots or self.shots or self._is_state_backend):
             warnings.warn(self.analytic_warning_message.format(self.backend_name), UserWarning)
-            # self.shots = 1024
-            circuit._shots = Shots(1024)  # pylint:disable=protected-access
+            circuit = qml.set_shots(circuit, 1024)
         return super().expand_fn(circuit, max_expansion)
 
     def process_kwargs(self, kwargs):

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -142,12 +142,20 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
 
         self.process_kwargs(kwargs)
 
-    def expand_fn(self, tape, max_expansion=10):
+    def expand_fn(self, circuit, max_expansion=10):
         """Expand the circuit"""
-        if not (tape.shots or self.shots or self._is_state_backend):
+        if not (circuit.shots or self.shots or self._is_state_backend):
             warnings.warn(self.analytic_warning_message.format(self.backend_name), UserWarning)
-            tape = tape.copy(shots=1024)
-        return super().expand_fn(tape, max_expansion)
+            circuit = circuit.copy(shots=1024)
+        return super().expand_fn(circuit, max_expansion)
+
+    def batch_transform(self, circuit):
+        """Batch transform the circuit"""
+        if not (circuit.shots or self.shots or self._is_state_backend):
+            warnings.warn(self.analytic_warning_message.format(self.backend_name), UserWarning)
+            circuit = circuit.copy(shots=1024)
+
+        return super().batch_transform(circuit)
 
     def process_kwargs(self, kwargs):
         """Processing the keyword arguments that were provided upon device initialization.
@@ -454,9 +462,6 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
 
         # Shots preprocessing
         shots = circuits[0].shots.total_shots or self.shots
-        if not (shots or self._is_state_backend):
-            warnings.warn(self.analytic_warning_message.format(self.backend_name), UserWarning)
-            shots = 1024
         if not self.shots:
             self._shots = shots
         # Send the batch of circuit objects using backend.run

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -454,7 +454,7 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
 
         # Shots preprocessing
         shots = circuits[0].shots.total_shots or self.shots
-        if not shots:
+        if not (shots or self._is_state_backend):
             warnings.warn(self.analytic_warning_message.format(self.backend_name), UserWarning)
             shots = 1024
         if not self.shots:

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -153,8 +153,8 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
         """Expand the circuit"""
         if not (circuit.shots or self.shots or self._is_state_backend):
             warnings.warn(self.analytic_warning_message.format(self.backend_name), UserWarning)
-            self.shots = 1024
-            circuit._shots = Shots(1024)
+            # self.shots = 1024
+            circuit._shots = Shots(1024)  # pylint:disable=protected-access
         return super().expand_fn(circuit, max_expansion)
 
     def process_kwargs(self, kwargs):

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -143,12 +143,12 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
 
         self.process_kwargs(kwargs)
 
-    def expand_fn(self, circuit, max_expansion=10):
+    def expand_fn(self, tape, max_expansion=10):
         """Expand the circuit"""
-        if not (circuit.shots or self.shots or self._is_state_backend):
+        if not (tape.shots or self.shots or self._is_state_backend):
             warnings.warn(self.analytic_warning_message.format(self.backend_name), UserWarning)
-            circuit = set_shots(circuit, 1024)
-        return super().expand_fn(circuit, max_expansion)
+            tape = tape.copy(shots=1024)
+        return super().expand_fn(tape, max_expansion)
 
     def process_kwargs(self, kwargs):
         """Processing the keyword arguments that were provided upon device initialization.
@@ -455,6 +455,9 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
 
         # Shots preprocessing
         shots = circuits[0].shots.total_shots or self.shots
+        if not shots:
+            warnings.warn(self.analytic_warning_message.format(self.backend_name), UserWarning)
+            shots = 1024
         if not self.shots:
             self._shots = shots
         # Send the batch of circuit objects using backend.run

--- a/pennylane_qiskit/qiskit_device_legacy.py
+++ b/pennylane_qiskit/qiskit_device_legacy.py
@@ -29,7 +29,8 @@ from qiskit.providers import Backend, BackendV2, QiskitBackendNotFoundError
 
 from pennylane.exceptions import DeviceError
 from pennylane.devices import QubitDevice
-from pennylane.measurements import SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP, Shots
+from pennylane.measurements import SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP
+from pennylane.workflow import set_shots
 
 from .converter import QISKIT_OPERATION_MAP
 from ._version import __version__
@@ -126,7 +127,6 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
 
             self.backend_name = _get_backend_name(self._backend)
 
-
         self._capabilities["returns_state"] = self._is_state_backend
 
         # Perform validation against backend
@@ -147,7 +147,7 @@ class QiskitDeviceLegacy(QubitDevice, abc.ABC):
         """Expand the circuit"""
         if not (circuit.shots or self.shots or self._is_state_backend):
             warnings.warn(self.analytic_warning_message.format(self.backend_name), UserWarning)
-            circuit = qml.set_shots(circuit, 1024)
+            circuit = set_shots(circuit, 1024)
         return super().expand_fn(circuit, max_expansion)
 
     def process_kwargs(self, kwargs):

--- a/pennylane_qiskit/remote.py
+++ b/pennylane_qiskit/remote.py
@@ -142,5 +142,5 @@ class RemoteDevice(QiskitDevice):
 
     short_name = "qiskit.remote"
 
-    def __init__(self, wires, backend, shots=1024, **kwargs):
+    def __init__(self, wires, backend, shots=None, **kwargs):
         super().__init__(wires, backend=backend, shots=shots, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,8 +138,7 @@ def device(request, backend, shots):
 
 
 @pytest.fixture(params=test_devices)
-def state_vector_device(request, statevector_backend, shots):
-
+def state_vector_device(request, statevector_backend):
     if backend == "aer_simulator" and not issubclass(request.param, AerDevice):
         pytest.skip("Only the AerDevice can use the aer_simulator backend")
 
@@ -150,7 +149,7 @@ def state_vector_device(request, statevector_backend, shots):
         pytest.skip("BasicSimulator is the only supported backend for the BasicSimulatorDevice")
 
     def _device(n):
-        return request.param(wires=n, backend=statevector_backend, shots=shots)
+        return request.param(wires=n, backend=statevector_backend)
 
     return _device
 

--- a/tests/test_base_device.py
+++ b/tests/test_base_device.py
@@ -1005,7 +1005,7 @@ class TestExecution:
         """
         Test that when no shots are set, a warning is issued.
         """
-        dev = QiskitDevice(wires=1, backend=aer_backend, shots=None)
+        dev = QiskitDevice(wires=1, backend=aer_backend)
 
         @qml.qnode(dev)
         def circuit():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -61,9 +61,9 @@ class TestDeviceIntegration:
         if not is_compatible:
             pytest.skip(failure_msg)
 
-        dev = qml.device(d[0], wires=2, backend=backend, shots=1024)
+        dev = qml.device(d[0], wires=2, backend=backend)
         assert dev.num_wires == 2
-        assert dev.shots.total_shots == 1024
+        assert dev.shots.total_shots == None
         assert dev.short_name == d[0]
         assert dev.provider == d[1]
 
@@ -84,10 +84,9 @@ class TestDeviceIntegration:
             "qiskit.remote",
             wires=backend_instance.configuration().n_qubits,
             backend=backend_instance,
-            shots=1024,
         )
         assert dev.num_wires == backend_instance.configuration().n_qubits
-        assert dev.shots.total_shots == 1024
+        assert dev.shots.total_shots == None
         assert dev.short_name == "qiskit.remote"
 
     def test_incorrect_backend(self):
@@ -107,11 +106,6 @@ class TestDeviceIntegration:
         with pytest.raises(TypeError, match="missing 1 required positional argument"):
             qml.device("qiskit.aer")
 
-        with pytest.raises(
-            qml.exceptions.DeviceError, match="specified number of shots needs to be at least 1"
-        ):
-            qml.device("qiskit.aer", wires=1, shots=0)
-
     @pytest.mark.parametrize("d", pldevices)
     @pytest.mark.parametrize("shots", [None, 8192])
     def test_one_qubit_circuit(self, shots, d, backend, tol):
@@ -125,12 +119,13 @@ class TestDeviceIntegration:
         if backend not in state_backends and shots is None:
             pytest.skip("Hardware simulators do not support analytic mode")
 
-        dev = qml.device(d[0], wires=1, backend=backend, shots=shots)
+        dev = qml.device(d[0], wires=1, backend=backend)
 
         a = 0.543
         b = 0.123
         c = 0.987
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(x, y, z):
             """Reference QNode"""
@@ -151,13 +146,14 @@ class TestDeviceIntegration:
         if not is_compatible:
             pytest.skip(failure_msg)
 
-        dev = qml.device(d[0], wires=1, backend=backend, shots=shots)
+        dev = qml.device(d[0], wires=1, backend=backend)
 
         a = 0
         b = 0
         c = np.pi
         expected = 1
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(x, y, z):
             """Reference QNode"""
@@ -184,7 +180,6 @@ class TestDeviceIntegration:
         dev_qsk = qml.device(
             "qiskit.aer",
             wires=n_qubits,
-            shots=1000,
             backend="qasm_simulator",
         )
 
@@ -192,6 +187,7 @@ class TestDeviceIntegration:
 
         # Want to get expectation value and gradient
         exp_sampled = qml.QNode(ansatz, dev_qsk, diff_method="parameter-shift")
+        qml.set_shots(exp_sampled, 1000)
         grad_shift = qml.grad(exp_sampled, argnum=0)
         exp_sampled(weights)
         grad_shift(weights)
@@ -338,6 +334,7 @@ class TestPLOperations:
         def rz(theta):
             return np.cos(theta / 2) * I + 1j * np.sin(-theta / 2) * Z
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def qubitstatevector_and_rot():
             qml.StatePrep(state, wires=[0])
@@ -358,6 +355,7 @@ class TestPLOperations:
         dev = state_vector_device(2)
         state = np.array([1, 0])
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def basisstate():
             qml.BasisState(state, wires=[0, 1])
@@ -378,6 +376,7 @@ class TestPLOperations:
         dev = state_vector_device(4)
         state = np.array([0, 0, 0, 0])
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def basisstate():
             qml.BasisState(state, wires=[0, 1, 2, 3])
@@ -400,6 +399,7 @@ class TestPLOperations:
 
         x = 1.23
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def rotate_back_and_forth():
             qml.RX(x, 0)
@@ -492,7 +492,7 @@ class TestInverses:
         by comparing a simple circuit with default.qubit."""
         dev = qml.device("default.qubit", wires=2)
 
-        dev2 = qml.device("qiskit.aer", backend="statevector_simulator", shots=None, wires=2)
+        dev2 = qml.device("qiskit.aer", backend="statevector_simulator", wires=2)
 
         angles = np.array([0.53896774, 0.79503606, 0.27826503, 0.0])
 
@@ -550,7 +550,7 @@ class TestBatchExecution:
         if backend not in state_backends and shots is None:
             pytest.skip("Hardware simulators do not support analytic mode")
 
-        dev = qml.device(d[0], wires=1, backend=backend, shots=shots)
+        dev = qml.device(d[0], wires=1, backend=backend)
 
         # Batch the input parameters
         batch_dim = 3
@@ -561,6 +561,7 @@ class TestBatchExecution:
         spy1 = mocker.spy(QiskitDeviceLegacy, "batch_execute")
         spy2 = mocker.spy(dev.backend, "run")
 
+        @qml.set_shots(shots)
         @partial(qml.batch_params, all_operations=True)
         @qml.qnode(dev)
         def circuit(x, y, z):
@@ -590,11 +591,12 @@ class TestBatchExecution:
         if backend not in state_backends and shots is None:
             pytest.skip("Hardware simulators do not support analytic mode")
 
-        dev = qml.device(d[0], wires=3, backend=backend, shots=shots)
+        dev = qml.device(d[0], wires=3, backend=backend)
 
         spy1 = mocker.spy(QiskitDeviceLegacy, "batch_execute")
         spy2 = mocker.spy(dev.backend, "run")
 
+        @qml.set_shots(shots)
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit(x, y):
             qml.RX(x, wires=[0])
@@ -618,8 +620,9 @@ class TestBatchExecution:
 
     def test_tracker(self):
         """Tests the device tracker with batch execution."""
-        dev = qml.device("qiskit.aer", shots=100, wires=3)
+        dev = qml.device("qiskit.aer", wires=3)
 
+        @qml.set_shots(100)
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit(x):
             qml.RX(x, wires=0)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -63,7 +63,7 @@ class TestDeviceIntegration:
 
         dev = qml.device(d[0], wires=2, backend=backend)
         assert dev.num_wires == 2
-        assert dev.shots.total_shots == None
+        assert dev.shots.total_shots is None
         assert dev.short_name == d[0]
         assert dev.provider == d[1]
 
@@ -86,7 +86,7 @@ class TestDeviceIntegration:
             backend=backend_instance,
         )
         assert dev.num_wires == backend_instance.configuration().n_qubits
-        assert dev.shots.total_shots == None
+        assert dev.shots.total_shots is None
         assert dev.short_name == "qiskit.remote"
 
     def test_incorrect_backend(self):

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -172,18 +172,22 @@ class TestAnalyticWarningHWSimulator:
         """Tests that a warning is raised if the analytic attribute is true on
         hardware simulators when calculating the expectation"""
 
-        with pytest.warns(UserWarning) as record:
-            dev = qml.device("qiskit.aer", backend="aer_simulator", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", backend="aer_simulator", wires=2, shots=None)
 
-        assert (
-            record[-1].message.args[0] == "The analytic calculation of "
+        @qml.qnode(dev)
+        def circuit():
+            qml.RX(np.pi / 2, wires=[0])
+            return qml.expval(qml.PauliZ(0))
+
+        with pytest.warns(
+            UserWarning,
+            match="The analytic calculation of "
             "expectations, variances and probabilities is only supported on "
             f"statevector backends, not on the {dev.backend.name}. Such statistics obtained from this "
-            "device are estimates based on samples."
-        )
+            "device are estimates based on samples.",
+        ):
 
-        # One warning raised about analytic calculations.
-        assert len(record) == 1
+            circuit()
 
     @pytest.mark.parametrize("method", ["unitary", "statevector"])
     def test_no_warning_raised_for_software_backend_analytic_expval(


### PR DESCRIPTION
In favour of our new shots api (i.e. the shots information should be only stored on qnode and tapes, instead of devices), the shots setting at device initialization has been deprecated on PennyLane. To ease the transition on the side of plugins, qiskit plugin need to also change the default shots to `None` and also when and where to emit the warning. The best candidate up to now is the `expand_fn` or `batch_execute` because legacy facade will apply these two first before actually executing any circuit(s) on the legacy device.