### PR TITLE
create `pytest.ini` to raise PLDW as errors

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[tool:pytest]
+filterwarnings =
+    error::pennylane.exceptions.PennyLaneDeprecationWarning

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,3 +1,3 @@
-[tool:pytest]
+[pytest]
 filterwarnings =
     error::pennylane.exceptions.PennyLaneDeprecationWarning


### PR DESCRIPTION
So that we can catch `PennyLaneDeprecationWarning` before it errors out in PTM