### PR TITLE
fix: add clarifaction about non-physical wire labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,17 @@
 
 ### Documentation 📝
 
+* Improve documentation for the plugin.
+  [(#697)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/697)
+
 ### Bug fixes 🐛
 
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
 
-Astral Cai
+Astral Cai,
+Andrija Paurevic.
 
 ---
 

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,13 @@ If you wish to develop the PennyLane-Qiskit plugin, please first install the dev
 
     python -m pip install -r requirements-dev.txt
 
-and install the pre-commit hooks with
+followed by an edittable installation of the plugin with
+
+.. code-block:: bash
+
+    python -m pip install -e .
+
+Optionally, you can install the pre-commit hooks with
 
 .. code-block:: bash
 

--- a/doc/devices/remote.rst
+++ b/doc/devices/remote.rst
@@ -86,13 +86,13 @@ or `runtime <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/options>`_, sim
     )
 
 This device is not compatible with analytic mode, so an error will be raised if ``shots=0`` or ``shots=None``.
-The default value of the shots argument is ``1024``. You can set the number of shots on device initialization using the 
-``shots`` keyword, or you can choose the number of shots on circuit execution.
+The default value of the shots argument is ``1024``. You can set the number of shots using the ``set_shots`` transform,
 
 .. code-block:: python
 
-    dev = qml.device("qiskit.remote", wires=5, backend=backend, shots=4096)
+    dev = qml.device("qiskit.remote", wires=5, backend=backend)
 
+    @qml.set_shots(4096)
     @qml.qnode(dev)
     def circuit(x, y, z):
         qml.RZ(z, wires=[0])
@@ -105,4 +105,5 @@ The default value of the shots argument is ``1024``. You can set the number of s
     circuit(0.2, 0.1, 0.3)
 
     # Runs with 10000 shots
-    circuit(0.2, 0.1, 0.3, shots=10000)
+    new_circuit = qml.set_shots(circuit, 10_000)
+    new_circuit(0.2, 0.1, 0.3)

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -292,21 +292,27 @@ def split_execution_types(
 
 @custom_simulator_tracking
 class QiskitDevice(Device):
-    r"""Hardware/simulator Qiskit device for PennyLane.
+    r"""Constructs a hardware/simulator Qiskit device for PennyLane.
 
     Args:
-        wires (int or Iterable[Number, str]): Number of subsystems represented by the device,
+        wires (int | Iterable[Number, str]): Number of subsystems represented by the device,
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['aux_wire', 'q1', 'q2']``).
+
+            .. note::
+
+                Custom wire labels (e.g., strings or non-consecutive integers) are used for user convenience only.
+                They have no effect on the transpilation process or the final qubit layout on the hardware.
+
         backend (Backend): the initialized Qiskit backend
 
     Keyword Args:
-        shots (int or None): number of circuit evaluations/random samples used
+        shots (int | None): number of circuit evaluations/random samples used
             to estimate expectation values and variances of observables. Note that
             if `shots=None`, the Qiskit backend will select a default.
-        session (Session): a Qiskit Session to use for device execution. If none is provided, a session will
+        session (Session | None): a Qiskit Session to use for device execution. If none is provided, a session will
             be created at each device execution.
-        compile_backend (Union[Backend, None]): the backend to be used for compiling the circuit that will be
+        compile_backend (Backend | None): the backend to be used for compiling the circuit that will be
             sent to the backend device, to be set if the backend desired for compilation differs from the
             backend used for execution. Defaults to ``None``, which means the primary backend will be used.
         **kwargs: transpilation and runtime keyword arguments to be used for measurements with Primitives.

--- a/pennylane_qiskit/qiskit_device.py
+++ b/pennylane_qiskit/qiskit_device.py
@@ -292,7 +292,7 @@ def split_execution_types(
 
 @custom_simulator_tracking
 class QiskitDevice(Device):
-    r"""Constructs a hardware/simulator Qiskit device for PennyLane.
+    r"""Construct a hardware/simulator Qiskit device for PennyLane.
 
     Args:
         wires (int | Iterable[Number, str]): Number of subsystems represented by the device,

--- a/pennylane_qiskit/remote.py
+++ b/pennylane_qiskit/remote.py
@@ -23,17 +23,23 @@ class RemoteDevice(QiskitDevice):
     """A PennyLane device for any Qiskit backend.
 
     Args:
-        wires (int or Iterable[Number, str]): Number of subsystems represented by the device,
+        wires (int | Iterable[Number, str]): Number of subsystems represented by the device,
             or iterable that contains unique labels for the subsystems as numbers
             (i.e., ``[-1, 0, 2]``) or strings (``['aux_wire', 'q1', 'q2']``).
+
+            .. note::
+
+                Custom wire labels (e.g., strings or non-consecutive integers) are used for user convenience only.
+                They have no effect on the transpilation process or the final qubit layout on the hardware.
+
         backend (Backend): the initialized Qiskit backend
 
     Keyword Args:
-        shots (Union[int, None]): number of circuit evaluations/random samples used
+        shots (int | None): number of circuit evaluations/random samples used
             to estimate expectation values and variances of observables.
-        session (Session): a Qiskit Session to use for device execution. If none is provided,
+        session (Session | None): a Qiskit Session to use for device execution. If none is provided,
             a session will be created at each device execution.
-        compile_backend (Union[Backend, None]): the backend to be used for compiling the circuit
+        compile_backend (Backend | None): the backend to be used for compiling the circuit
             that will be sent to the backend device, to be set if the backend desired for
             compilation differs from the backend used for execution. Defaults to ``None``,
             which means the primary backend will be used.

--- a/pennylane_qiskit/remote.py
+++ b/pennylane_qiskit/remote.py
@@ -61,13 +61,13 @@ class RemoteDevice(QiskitDevice):
         backend = service.least_busy(n_qubits=127, simulator=False, operational=True)
         dev = qml.device("qiskit.remote", wires=127, backend=backend)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=1024)
         def circuit(x):
             qml.RX(x, wires=[0])
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(1))
 
-    >>> circuit(np.pi/3, shots=1024)
+    >>> circuit(np.pi/3)
     0.529296875
 
     This device also supports the use of local simulators such as ``AerSimulator`` or
@@ -81,13 +81,13 @@ class RemoteDevice(QiskitDevice):
         backend = AerSimulator()
         dev = qml.device("qiskit.remote", wires=5, backend=backend)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=1024)
         def circuit(x):
             qml.RX(x, wires=[0])
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(1))
 
-    >>> circuit(np.pi/3, shots=1024)
+    >>> circuit(np.pi/3)
     0.49755859375
 
     We can also change the number of shots, either when initializing the device or when we execute
@@ -96,9 +96,9 @@ class RemoteDevice(QiskitDevice):
 
     .. code-block:: python
 
-        dev = qml.device("qiskit.remote", wires=5, backend=backend, shots=2)
+        dev = qml.device("qiskit.remote", wires=5, backend=backend)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=2)
         def circuit(x):
             qml.RX(x, wires=[0])
             qml.CNOT(wires=[0, 1])
@@ -107,7 +107,8 @@ class RemoteDevice(QiskitDevice):
     >>> circuit(np.pi/3) # this will run with 2 shots
     array([-1.,  1.])
 
-    >>> circuit(np.pi/3, shots=5) # this will run with 5 shots
+    >>> new_circuit = qml.set_shots(circuit, 5)
+    >>> new_circuit(np.pi/3) # this will run with 5 shots
     array([-1., -1.,  1.,  1.,  1.])
 
     >>> circuit(np.pi/3) # this will run with 2 shots


### PR DESCRIPTION
This PR does general documentation improvements. 

However, the most important change is that we're letting users know that non-physical wire labels are purely for convenience and don't inform any hardware transpilation.

[sc-113246]