### PR TITLE
fix: pass correct wire counts in noise model tests

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2664,15 +2664,21 @@ class TestLoadNoiseModel:
             {fcond: partial_wires(noise) for fcond, noise in pl_model_map.items()}
         )
 
-        for (pl_k, pl_v), (qk_k, qk_v) in zip(
-            pl_noise_model.model_map.items(), loaded_noise_model.model_map.items()
+        for (pl_k, _), (qk_k, qk_v), noise_op in zip(
+            pl_noise_model.model_map.items(),
+            loaded_noise_model.model_map.items(),
+            pl_model_map.values(),
+            strict=True,
         ):
-            pl_op, qk_op = pl_v("ANY"), qk_v("ANY")
             assert repr(pl_k) == repr(qk_k)
+            ref_kraus = noise_op.compute_kraus_matrices(*noise_op.data)
+            num_wires = int(np.log2(ref_kraus[0].shape[0]))
+            test_wires = list(range(num_wires))
+            qk_op = qk_v(test_wires)
             assert isinstance(qk_op, qml.QubitChannel)
 
             choi_mat1 = self._kraus_to_choi(qk_op.data)
-            choi_mat2 = self._kraus_to_choi(pl_op.compute_kraus_matrices(*pl_op.data))
+            choi_mat2 = self._kraus_to_choi(ref_kraus)
             assert np.allclose(choi_mat1, choi_mat2)
 
     @pytest.mark.parametrize(
@@ -2697,23 +2703,32 @@ class TestLoadNoiseModel:
         )
         pauli_prob1 = np.sqrt(error_1.probabilities)
         pauli_prob2 = np.sqrt(error_2.probabilities)
-        kraus_ops1 = [prob * kraus_op for prob, kraus_op in zip(pauli_prob1, pauli_mats1)]
-        kraus_ops2 = [prob * kraus_op for prob, kraus_op in zip(pauli_prob2, pauli_mats2)]
+        kraus_ops1 = [
+            prob * kraus_op for prob, kraus_op in zip(pauli_prob1, pauli_mats1, strict=True)
+        ]
+        kraus_ops2 = [
+            prob * kraus_op for prob, kraus_op in zip(pauli_prob2, pauli_mats2, strict=True)
+        ]
 
         c0 = qml.noise.op_in([qml.RZ, qml.RY])
         c1 = qml.noise.op_in(qml.CNOT)
         n0 = qml.noise.partial_wires(qml.QubitChannel(kraus_ops1, wires=[0]))
         n1 = qml.noise.partial_wires(qml.QubitChannel(kraus_ops2, wires=[0, 1]))
         pl_noise_model = qml.NoiseModel({c0: n0, c1: n1})
+        num_wires_list = [1, 2]  # n0 is 1-qubit, n1 is 2-qubit
 
-        for (pl_k, pl_v), (qk_k, qk_v) in zip(
-            pl_noise_model.model_map.items(), loaded_noise_model.model_map.items()
+        for (pl_k, pl_v), (qk_k, qk_v), num_wires in zip(
+            pl_noise_model.model_map.items(),
+            loaded_noise_model.model_map.items(),
+            num_wires_list,
+            strict=True,
         ):
             assert repr(pl_k) == repr(qk_k)
+            test_wires = list(range(num_wires))
 
-            pl_data = np.array(pl_v("ANY").data)
+            pl_data = np.array(pl_v(test_wires).data)
             if verbose:
-                choi_mat1 = self._kraus_to_choi(qk_v("ANY").data)
+                choi_mat1 = self._kraus_to_choi(qk_v(test_wires).data)
                 choi_mat2 = self._kraus_to_choi(pl_data)
                 assert np.allclose(choi_mat1, choi_mat2)
             else:


### PR DESCRIPTION
## Context

The upstream PennyLane change ([PR #9406](https://github.com/PennyLaneAI/pennylane/pull/9406)) added `strict=True` to `zip()` in `partial_wires`, which now raises `ValueError` when wire counts mismatch. Previously, zip silently truncated, hiding the fact that multi-qubit noise channels were being tested with single-wire `'ANY'`.

## Changes

- test_build_noise_model: compute wire count from reference Kraus matrix dimensions and compare directly against loaded model
- test_build_noise_model_with_args: pass explicit wire lists matching the 1-qubit and 2-qubit channel sizes
- Add `strict=True` to all zip calls in these tests
[sc-119881]