### PR TITLE
Stop using deprecated shots kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Improvements 🛠
 
+* Updated tests to stop using deprecated shots kwarg on the device.
+  [(#708)](https://github.com/PennyLaneAI/pennylane-qiskit/pull/708)
+
 ### Breaking changes 💔
 
 ### Deprecations 👋
@@ -15,6 +18,8 @@
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Marcus Edwards
 
 ---
 # Release 0.45.0

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1406,9 +1406,9 @@ class TestConverterIntegration:
         # convert to a PennyLane circuit
         qc_pl = qml.from_qiskit(qc)
 
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit", wires=3)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=shots)
         def circuit(params):
             qiskit_param_mapping = dict(map(list, zip(qiskit_params, params)))
             qc_pl(qiskit_param_mapping)
@@ -1437,9 +1437,9 @@ class TestConverterIntegration:
 
         pl_circuit_loader = qml.from_qiskit(qiskit_circuit)
 
-        dev = qml.device("default.qubit", wires=1, shots=shots)
+        dev = qml.device("default.qubit", wires=1)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=shots)
         def circuit(theta):
             pl_circuit_loader(params={theta_param: theta})
             return qml.expval(qml.PauliZ(0))
@@ -1470,9 +1470,9 @@ class TestConverterIntegration:
 
         pl_circuit_loader = qml.from_qiskit(qiskit_circuit)
 
-        dev = qml.device("default.qubit", wires=1, shots=shots)
+        dev = qml.device("default.qubit", wires=1)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=shots)
         def circuit(phi, theta):
             pl_circuit_loader(params={phi_param: phi, theta_param: theta})
             return qml.expval(qml.PauliZ(0))
@@ -1503,9 +1503,9 @@ class TestConverterIntegration:
         # convert to a PennyLane circuit
         qc_pl = qml.from_qiskit(qc)
 
-        dev = qml.device("default.qubit", wires=3, shots=shots)
+        dev = qml.device("default.qubit", wires=3)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=shots)
         def circuit(params):
             qiskit_param_mapping = dict(map(list, zip(qiskit_params, params)))
             qc_pl(qiskit_param_mapping)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2664,21 +2664,15 @@ class TestLoadNoiseModel:
             {fcond: partial_wires(noise) for fcond, noise in pl_model_map.items()}
         )
 
-        for (pl_k, _), (qk_k, qk_v), noise_op in zip(
-            pl_noise_model.model_map.items(),
-            loaded_noise_model.model_map.items(),
-            pl_model_map.values(),
-            strict=True,
+        for (pl_k, pl_v), (qk_k, qk_v) in zip(
+            pl_noise_model.model_map.items(), loaded_noise_model.model_map.items()
         ):
+            pl_op, qk_op = pl_v("ANY"), qk_v("ANY")
             assert repr(pl_k) == repr(qk_k)
-            ref_kraus = noise_op.compute_kraus_matrices(*noise_op.data)
-            num_wires = int(np.log2(ref_kraus[0].shape[0]))
-            test_wires = list(range(num_wires))
-            qk_op = qk_v(test_wires)
             assert isinstance(qk_op, qml.QubitChannel)
 
             choi_mat1 = self._kraus_to_choi(qk_op.data)
-            choi_mat2 = self._kraus_to_choi(ref_kraus)
+            choi_mat2 = self._kraus_to_choi(pl_op.compute_kraus_matrices(*pl_op.data))
             assert np.allclose(choi_mat1, choi_mat2)
 
     @pytest.mark.parametrize(
@@ -2703,32 +2697,23 @@ class TestLoadNoiseModel:
         )
         pauli_prob1 = np.sqrt(error_1.probabilities)
         pauli_prob2 = np.sqrt(error_2.probabilities)
-        kraus_ops1 = [
-            prob * kraus_op for prob, kraus_op in zip(pauli_prob1, pauli_mats1, strict=True)
-        ]
-        kraus_ops2 = [
-            prob * kraus_op for prob, kraus_op in zip(pauli_prob2, pauli_mats2, strict=True)
-        ]
+        kraus_ops1 = [prob * kraus_op for prob, kraus_op in zip(pauli_prob1, pauli_mats1)]
+        kraus_ops2 = [prob * kraus_op for prob, kraus_op in zip(pauli_prob2, pauli_mats2)]
 
         c0 = qml.noise.op_in([qml.RZ, qml.RY])
         c1 = qml.noise.op_in(qml.CNOT)
         n0 = qml.noise.partial_wires(qml.QubitChannel(kraus_ops1, wires=[0]))
         n1 = qml.noise.partial_wires(qml.QubitChannel(kraus_ops2, wires=[0, 1]))
         pl_noise_model = qml.NoiseModel({c0: n0, c1: n1})
-        num_wires_list = [1, 2]  # n0 is 1-qubit, n1 is 2-qubit
 
-        for (pl_k, pl_v), (qk_k, qk_v), num_wires in zip(
-            pl_noise_model.model_map.items(),
-            loaded_noise_model.model_map.items(),
-            num_wires_list,
-            strict=True,
+        for (pl_k, pl_v), (qk_k, qk_v) in zip(
+            pl_noise_model.model_map.items(), loaded_noise_model.model_map.items()
         ):
             assert repr(pl_k) == repr(qk_k)
-            test_wires = list(range(num_wires))
 
-            pl_data = np.array(pl_v(test_wires).data)
+            pl_data = np.array(pl_v("ANY").data)
             if verbose:
-                choi_mat1 = self._kraus_to_choi(qk_v(test_wires).data)
+                choi_mat1 = self._kraus_to_choi(qk_v("ANY").data)
                 choi_mat2 = self._kraus_to_choi(pl_data)
                 assert np.allclose(choi_mat1, choi_mat2)
             else:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2664,15 +2664,21 @@ class TestLoadNoiseModel:
             {fcond: partial_wires(noise) for fcond, noise in pl_model_map.items()}
         )
 
-        for (pl_k, pl_v), (qk_k, qk_v) in zip(
-            pl_noise_model.model_map.items(), loaded_noise_model.model_map.items()
+        for (pl_k, _), (qk_k, qk_v), noise_op in zip(
+            pl_noise_model.model_map.items(),
+            loaded_noise_model.model_map.items(),
+            pl_model_map.values(),
+            strict=True,
         ):
-            pl_op, qk_op = pl_v("ANY"), qk_v("ANY")
             assert repr(pl_k) == repr(qk_k)
+            ref_kraus = noise_op.compute_kraus_matrices(*noise_op.data)
+            num_wires = int(np.log2(ref_kraus[0].shape[0]))
+            test_wires = list(range(num_wires))
+            qk_op = qk_v(test_wires)
             assert isinstance(qk_op, qml.QubitChannel)
 
             choi_mat1 = self._kraus_to_choi(qk_op.data)
-            choi_mat2 = self._kraus_to_choi(pl_op.compute_kraus_matrices(*pl_op.data))
+            choi_mat2 = self._kraus_to_choi(ref_kraus)
             assert np.allclose(choi_mat1, choi_mat2)
 
     @pytest.mark.parametrize(
@@ -2697,23 +2703,32 @@ class TestLoadNoiseModel:
         )
         pauli_prob1 = np.sqrt(error_1.probabilities)
         pauli_prob2 = np.sqrt(error_2.probabilities)
-        kraus_ops1 = [prob * kraus_op for prob, kraus_op in zip(pauli_prob1, pauli_mats1)]
-        kraus_ops2 = [prob * kraus_op for prob, kraus_op in zip(pauli_prob2, pauli_mats2)]
+        kraus_ops1 = [
+            prob * kraus_op for prob, kraus_op in zip(pauli_prob1, pauli_mats1, strict=True)
+        ]
+        kraus_ops2 = [
+            prob * kraus_op for prob, kraus_op in zip(pauli_prob2, pauli_mats2, strict=True)
+        ]
 
         c0 = qml.noise.op_in([qml.RZ, qml.RY])
         c1 = qml.noise.op_in(qml.CNOT)
         n0 = qml.noise.partial_wires(qml.QubitChannel(kraus_ops1, wires=[0]))
         n1 = qml.noise.partial_wires(qml.QubitChannel(kraus_ops2, wires=[0, 1]))
         pl_noise_model = qml.NoiseModel({c0: n0, c1: n1})
+        num_wires_list = [1, 2]  # n0 is 1-qubit, n1 is 2-qubit
 
-        for (pl_k, pl_v), (qk_k, qk_v) in zip(
-            pl_noise_model.model_map.items(), loaded_noise_model.model_map.items()
+        for (pl_k, pl_v), (qk_k, qk_v), num_wires in zip(
+            pl_noise_model.model_map.items(),
+            loaded_noise_model.model_map.items(),
+            num_wires_list,
+            strict=True,
         ):
             assert repr(pl_k) == repr(qk_k)
+            test_wires = list(range(num_wires))
 
-            pl_data = np.array(pl_v("ANY").data)
+            pl_data = np.array(pl_v(test_wires).data)
             if verbose:
-                choi_mat1 = self._kraus_to_choi(qk_v("ANY").data)
+                choi_mat1 = self._kraus_to_choi(qk_v(test_wires).data)
                 choi_mat2 = self._kraus_to_choi(pl_data)
                 assert np.allclose(choi_mat1, choi_mat2)
             else:

--- a/tests/test_inverses.py
+++ b/tests/test_inverses.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 Xanadu Quantum Technologies Inc.
+# Copyright 2021-2026 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,9 +49,9 @@ class TestInverses:
 
         op = getattr(qml.ops, name)
 
-        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=None)
         def circuit():
             qml.adjoint(op(wires=0))
             return qml.expval(qml.PauliZ(0))
@@ -72,11 +72,11 @@ class TestInverses:
 
         op = getattr(qml.ops, name)
 
-        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2)
 
         assert dev.supports_operation(name)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=None)
         def circuit():
             qml.StatePrep(np.array([1 / 2, 0, 0, math.sqrt(3) / 2]), wires=[0, 1])
             qml.adjoint(op(wires=[0, 1]))
@@ -95,11 +95,11 @@ class TestInverses:
 
         op = getattr(qml.ops, name)
 
-        dev = qml.device("qiskit.aer", method="statevector", wires=3, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=3)
 
         assert dev.supports_operation(name)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=None)
         def circuit():
             qml.BasisState(np.array([1, 0, 1]), wires=[0, 1, 2])
             qml.adjoint(op(wires=[0, 1, 2]))
@@ -148,13 +148,13 @@ class TestInverses:
     def test_supported_gate_inverse_single_wire_with_parameters(self, name, par, expected_output):
         """Test the inverse of single gates with parameters"""
 
-        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2)
 
         op = getattr(qml.ops, name)
 
         assert dev.supports_operation(name)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=None)
         def circuit():
             qml.adjoint(op(*np.negative(par), wires=0))
             return qml.expval(qml.PauliZ(0))
@@ -201,13 +201,13 @@ class TestInverses:
     def test_supported_gate_inverse_two_wires_with_parameters(self, name, par, expected_output):
         """Tests the inverse of supported gates that act on two wires that are parameterized"""
 
-        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2)
 
         op = getattr(qml.ops, name)
 
         assert dev.supports_operation(name)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=None)
         def circuit():
             qml.StatePrep(np.array([1 / 2, 0, 0, math.sqrt(3) / 2]), wires=[0, 1])
             qml.adjoint(op(*np.negative(par), wires=[0, 1]))
@@ -229,11 +229,11 @@ class TestInverses:
     def test_unsupported_gate_inverses(self, name, par, expected_output):
         """Test the inverse of single gates with parameters"""
 
-        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2)
 
         op = getattr(qml.ops, name)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=None)
         def circuit():
             qml.adjoint(op(*np.negative(par), wires=0))
             return qml.expval(qml.PauliZ(0))
@@ -244,11 +244,11 @@ class TestInverses:
     def test_s_gate_inverses(self, par):
         """Tests the inverse of the S gate"""
 
-        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2)
 
         expected_output = -0.5 * 1j * cmath.exp(-1j * par) * (-1 + cmath.exp(2j * par))
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=None)
         def circuit():
             qml.Hadamard(0)
             qml.RZ(par, wires=[0])
@@ -261,11 +261,11 @@ class TestInverses:
     def test_t_gate_inverses(self, par):
         """Tests the inverse of the T gate"""
 
-        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2)
 
         expected_output = -math.sin(par) / math.sqrt(2)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=None)
         def circuit():
             qml.RX(par, wires=[0])
             qml.adjoint(qml.T(wires=[0]))
@@ -277,11 +277,11 @@ class TestInverses:
     def test_sx_gate_inverses(self, par):
         """Tests the inverse of the SX gate"""
 
-        dev = qml.device("qiskit.aer", method="statevector", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", method="statevector", wires=2)
 
         expected_output = math.sin(par)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=None)
         def circuit():
             qml.RY(par, wires=[0])
             qml.adjoint(qml.SX(wires=[0]))

--- a/tests/test_qiskit_device.py
+++ b/tests/test_qiskit_device.py
@@ -139,9 +139,9 @@ class TestAnalyticWarningHWSimulator:
         """Tests that a warning is raised if the analytic attribute is true on
         hardware simulators when calculating the expectation"""
 
-        dev = qml.device("qiskit.aer", backend="aer_simulator", wires=2, shots=None)
+        dev = qml.device("qiskit.aer", backend="aer_simulator", wires=2)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=None)
         def circuit():
             qml.RX(np.pi / 2, wires=[0])
             return qml.expval(qml.PauliZ(0))
@@ -163,7 +163,7 @@ class TestAnalyticWarningHWSimulator:
         """Tests that no warning is raised if the analytic attribute is true on
         statevector simulators when calculating the expectation"""
 
-        _ = qml.device("qiskit.aer", backend="aer_simulator", method=method, wires=2, shots=None)
+        _ = qml.device("qiskit.aer", backend="aer_simulator", method=method, wires=2)
 
         # These simulators are being deprecated. Warnings are raised in Qiskit <1.1
         assert len(recwarn) == 0


### PR DESCRIPTION
We would like to update the tests to stop setting the shots on the `device`, which is deprecated.

This PR makes sure that shots are set on the `qnode`. There are no downsides.

[sc-101299]